### PR TITLE
Rationalize program names

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -125,34 +125,34 @@
     </target>
 
     <target name="package-commands">
-        <package-command visibility="public" main-class="org.broadinstitute.dropseqrna.annotation.ValidateReference" title="ValidateReference"/>
-        <package-command visibility="public" main-class="org.broadinstitute.dropseqrna.annotation.CreateIntervalsFiles" title="CreateIntervalsFiles"/>
-        <package-command visibility="public" main-class="org.broadinstitute.dropseqrna.annotation.ConvertToRefFlat" title="ConvertToRefFlat"/>
-        <package-command visibility="public" main-class="org.broadinstitute.dropseqrna.annotation.ReduceGTF" title="ReduceGTF"/>
-        <package-command visibility="public" main-class="org.broadinstitute.dropseqrna.annotation.GatherGeneGCLength" title="GatherGeneGCLength"/>
-        <package-command visibility="public" main-class="org.broadinstitute.dropseqrna.utils.TagBamWithReadSequenceExtended" title="TagBamWithReadSequenceExtended"/>
-        <package-command visibility="public" main-class="org.broadinstitute.dropseqrna.metrics.BAMTagHistogram" title="BAMTagHistogram"/>
-        <package-command visibility="public" main-class="org.broadinstitute.dropseqrna.metrics.GatherReadQualityMetrics" title="GatherReadQualityMetrics"/>
-        <package-command visibility="public" main-class="org.broadinstitute.dropseqrna.metrics.BAMTagofTagCounts" title="BAMTagofTagCounts"/>
-        <package-command visibility="public" main-class="org.broadinstitute.dropseqrna.metrics.TagReadWithGeneFunction" title="TagReadWithGeneFunction"/>
-        <package-command visibility="public" main-class="org.broadinstitute.dropseqrna.metrics.TagReadWithGeneExonFunction" title="TagReadWithGeneExonFunction"/>
-        <package-command visibility="public" main-class="org.broadinstitute.dropseqrna.utils.BaseDistributionAtReadPosition" title="BaseDistributionAtReadPosition"/>
-        <package-command visibility="public" main-class="org.broadinstitute.dropseqrna.metrics.TagReadWithInterval" title="TagReadWithInterval"/>
-        <package-command visibility="public" main-class="org.broadinstitute.dropseqrna.barnyard.DigitalExpression" title="DigitalExpression"/>
-        <package-command visibility="public" main-class="org.broadinstitute.dropseqrna.barnyard.GatherMolecularBarcodeDistributionByGene" title="GatherMolecularBarcodeDistributionByGene"/>
-        <package-command visibility="public" main-class="org.broadinstitute.dropseqrna.barnyard.SingleCellRnaSeqMetricsCollector" title="SingleCellRnaSeqMetricsCollector"/>
-        <package-command visibility="public" main-class="org.broadinstitute.dropseqrna.readtrimming.PolyATrimmer" title="PolyATrimmer"/>
-        <package-command visibility="public" main-class="org.broadinstitute.dropseqrna.readtrimming.TrimStartingSequence" title="TrimStartingSequence"/>
-        <package-command visibility="public" main-class="org.broadinstitute.dropseqrna.utils.FilterBAM" title="FilterBAM"/>
-        <package-command visibility="public" main-class="org.broadinstitute.dropseqrna.beadsynthesis.DetectBeadSynthesisErrors" title="DetectBeadSynthesisErrors"/>
-        <package-command visibility="public" main-class="org.broadinstitute.dropseqrna.utils.FilterBAMByTag" title="FilterBAMByTag"/>
-        <package-command visibility="public" main-class="org.broadinstitute.dropseqrna.barnyard.SelectCellsByNumTranscripts" title="SelectCellsByNumTranscripts"/>
-        <package-command visibility="public" main-class="org.broadinstitute.dropseqrna.utils.editdistance.CollapseBarcodesInPlace" title="CollapseBarcodesInPlace"/>
-        <package-command visibility="public" main-class="org.broadinstitute.dropseqrna.utils.editdistance.CollapseTagWithContext" title="CollapseTagWithContext"/>
-        <package-command visibility="public" main-class="org.broadinstitute.dropseqrna.utils.editdistance.DetectBeadSubstitutionErrors" title="DetectBeadSubstitutionErrors"/>
-        <package-command visibility="public" main-class="org.broadinstitute.dropseqrna.utils.alignmentcomparison.CompareDropSeqAlignments" title="CompareDropSeqAlignments"/>
-        <package-command visibility="public" main-class="org.broadinstitute.dropseqrna.utils.referencetools.MaskReferenceSequence" title="MaskReferenceSequence"/>
-        <package-command visibility="public" main-class="org.broadinstitute.dropseqrna.cluster.MergeDgeSparse" title="MergeDgeSparse"/>
+        <package-command visibility="public" title="ValidateReference"/>
+        <package-command visibility="public" title="CreateIntervalsFiles"/>
+        <package-command visibility="public" title="ConvertToRefFlat"/>
+        <package-command visibility="public" title="ReduceGtf"/>
+        <package-command visibility="public" title="GatherGeneGCLength"/>
+        <package-command visibility="public" title="TagBamWithReadSequenceExtended"/>
+        <package-command visibility="public" title="BamTagHistogram"/>
+        <package-command visibility="public" title="GatherReadQualityMetrics"/>
+        <package-command visibility="public" title="BamTagOfTagCounts"/>
+        <package-command visibility="public" title="TagReadWithGeneFunction"/>
+        <package-command visibility="public" title="TagReadWithGeneExonFunction"/>
+        <package-command visibility="public" title="BaseDistributionAtReadPosition"/>
+        <package-command visibility="public" title="TagReadWithInterval"/>
+        <package-command visibility="public" title="DigitalExpression"/>
+        <package-command visibility="public" title="GatherMolecularBarcodeDistributionByGene"/>
+        <package-command visibility="public" title="SingleCellRnaSeqMetricsCollector"/>
+        <package-command visibility="public" title="PolyATrimmer"/>
+        <package-command visibility="public" title="TrimStartingSequence"/>
+        <package-command visibility="public" title="FilterBam"/>
+        <package-command visibility="public" title="DetectBeadSynthesisErrors"/>
+        <package-command visibility="public" title="FilterBamByTag"/>
+        <package-command visibility="public" title="SelectCellsByNumTranscripts"/>
+        <package-command visibility="public" title="CollapseBarcodesInPlace"/>
+        <package-command visibility="public" title="CollapseTagWithContext"/>
+        <package-command visibility="public" title="DetectBeadSubstitutionErrors"/>
+        <package-command visibility="public" title="CompareDropSeqAlignments"/>
+        <package-command visibility="public" title="MaskReferenceSequence"/>
+        <package-command visibility="public" title="MergeDgeSparse"/>
     </target>
 
 

--- a/src/ant/defs.xml
+++ b/src/ant/defs.xml
@@ -104,9 +104,8 @@
     </sequential>
 </macrodef>
 
-        <!-- Create script to invoke the given main program.  main-class is no longer necessary: should it be deleted? -->
+        <!-- Create script to invoke the given main program. -->
 <macrodef name="package-command">
-    <attribute name="main-class"/>
     <attribute name="title"/>
     <attribute name="visibility"/>
     <sequential>

--- a/src/java/org/broadinstitute/dropseqrna/annotation/ReduceGtf.java
+++ b/src/java/org/broadinstitute/dropseqrna/annotation/ReduceGtf.java
@@ -59,9 +59,9 @@ import java.util.Set;
         oneLineSummary = "Parse and simplify a GTF file into an easier to use format.",
         programGroup = MetaData.class
 )
-public class ReduceGTF extends CommandLineProgram {
+public class ReduceGtf extends CommandLineProgram {
 
-    private static final Log log = Log.getInstance(ReduceGTF.class);
+    private static final Log log = Log.getInstance(ReduceGtf.class);
     private static final List<String> DEFAULT_FEATURE_TYPES = CollectionUtil.makeList("gene", "transcript", "exon");
 
     private static final List<String> DEFAULT_IGNORED_FUNC_TYPES = CollectionUtil.makeList(
@@ -179,7 +179,7 @@ public class ReduceGTF extends CommandLineProgram {
 
 	/** Stock main method. */
 	public static void main(final String[] args) {
-		System.exit(new ReduceGTF().instanceMain(args));
+		System.exit(new ReduceGtf().instanceMain(args));
 	}
 
 

--- a/src/java/org/broadinstitute/dropseqrna/barnyard/BarcodeListRetrieval.java
+++ b/src/java/org/broadinstitute/dropseqrna/barnyard/BarcodeListRetrieval.java
@@ -26,8 +26,8 @@ package org.broadinstitute.dropseqrna.barnyard;
 import htsjdk.samtools.SAMRecord;
 import htsjdk.samtools.SamReaderFactory;
 import htsjdk.samtools.util.*;
-import org.broadinstitute.dropseqrna.metrics.BAMTagHistogram;
-import org.broadinstitute.dropseqrna.metrics.BAMTagofTagCounts;
+import org.broadinstitute.dropseqrna.metrics.BamTagHistogram;
+import org.broadinstitute.dropseqrna.metrics.BamTagOfTagCounts;
 import org.broadinstitute.dropseqrna.metrics.TagOfTagResults;
 import org.broadinstitute.dropseqrna.utils.ObjectCounter;
 import org.broadinstitute.dropseqrna.utils.readiterators.StrandStrategy;
@@ -119,7 +119,7 @@ public class BarcodeListRetrieval {
      */
     public List<String> getListCellBarcodesByReadCount(final CloseableIterator<SAMRecord> input, final String cellBarcodeTag, final int readQuality, final Integer minNumReads, final Integer numReadsCore) {
 
-        BAMTagHistogram bth = new BAMTagHistogram();
+        BamTagHistogram bth = new BamTagHistogram();
         ObjectCounter<String> cellBarcodes = bth.getBamTagCounts (input, cellBarcodeTag, readQuality, false);
 
         List<String> result=null;
@@ -135,7 +135,7 @@ public class BarcodeListRetrieval {
     public List<String> getListCellBarcodesByGeneCount(final File input, final String cellBarcodeTag, final String geneExonTag, final int readQuality, final int minNumGenes) {
 		List<String> result = new ArrayList<String>();
 
-		BAMTagofTagCounts tot = new BAMTagofTagCounts();
+		BamTagOfTagCounts tot = new BamTagOfTagCounts();
 		TagOfTagResults<String,String> results = tot.getResults(input, cellBarcodeTag, geneExonTag, false, readQuality);
 		for (String key: results.getKeys()) {
 			int count = results.getCount(key);
@@ -171,7 +171,7 @@ public class BarcodeListRetrieval {
 
 	/*
 	public List<String> getListCellBarcodesByGeneCount(File input, String cellBarcodeTag, int readQuality, int minNumGenes) {
-		BAMTagofTagCounts bt = new BAMTagofTagCounts();
+		BamTagOfTagCounts bt = new BamTagOfTagCounts();
 		// bt.
 	}
 	*/

--- a/src/java/org/broadinstitute/dropseqrna/metrics/BamTagHistogram.java
+++ b/src/java/org/broadinstitute/dropseqrna/metrics/BamTagHistogram.java
@@ -50,9 +50,9 @@ import java.util.List;
 @CommandLineProgramProperties(summary = "Create a histogram of values for the given tag",
         oneLineSummary = "Create a histogram of values for the given tag",
         programGroup = DropSeq.class)
-public class BAMTagHistogram extends CommandLineProgram {
+public class BamTagHistogram extends CommandLineProgram {
 
-	private static final Log log = Log.getInstance(BAMTagHistogram.class);
+	private static final Log log = Log.getInstance(BamTagHistogram.class);
 
 	@Argument(shortName = StandardOptionDefinitions.INPUT_SHORT_NAME, doc = "The input SAM or BAM file to analyze.  Must be coordinate sorted. (???)")
 	public File INPUT;
@@ -152,7 +152,7 @@ public class BAMTagHistogram extends CommandLineProgram {
 
 	/** Stock main method. */
 	public static void main(final String[] args) {
-		System.exit(new BAMTagHistogram().instanceMain(args));
+		System.exit(new BamTagHistogram().instanceMain(args));
 	}
 
 	/*

--- a/src/java/org/broadinstitute/dropseqrna/metrics/BamTagOfTagCounts.java
+++ b/src/java/org/broadinstitute/dropseqrna/metrics/BamTagOfTagCounts.java
@@ -53,9 +53,9 @@ import picard.cmdline.StandardOptionDefinitions;
         programGroup = DropSeq.class
 )
 
-public class BAMTagofTagCounts extends CommandLineProgram {
+public class BamTagOfTagCounts extends CommandLineProgram {
 
-private static final Log log = Log.getInstance(BAMTagofTagCounts.class);
+private static final Log log = Log.getInstance(BamTagOfTagCounts.class);
 
 	@Argument(shortName = StandardOptionDefinitions.INPUT_SHORT_NAME, doc = "The input SAM or BAM file to analyze.  Must be coordinate sorted. (???)")
 	public File INPUT;
@@ -183,7 +183,7 @@ private static final Log log = Log.getInstance(BAMTagofTagCounts.class);
 
 	/** Stock main method. */
 	public static void main(final String[] args) {
-		System.exit(new BAMTagofTagCounts().instanceMain(args));
+		System.exit(new BamTagOfTagCounts().instanceMain(args));
 	}
 
 

--- a/src/java/org/broadinstitute/dropseqrna/utils/FilterBam.java
+++ b/src/java/org/broadinstitute/dropseqrna/utils/FilterBam.java
@@ -48,8 +48,8 @@ import java.util.regex.Pattern;
 @CommandLineProgramProperties(summary = "Filters a BAM file by various qualities to produce a new subset of the BAM containing the reads of interest.",
         oneLineSummary = "Filters a BAM file by various qualities to produce a new subset of the BAM containing the reads of interest.",
         programGroup = DropSeq.class)
-public class FilterBAM extends CommandLineProgram{
-	private final Log log = Log.getInstance(FilterBAM.class);
+public class FilterBam extends CommandLineProgram{
+	private final Log log = Log.getInstance(FilterBam.class);
 
 	@Argument(shortName = StandardOptionDefinitions.INPUT_SHORT_NAME, doc = "The input SAM or BAM file to analyze.")
 	public File INPUT;
@@ -116,7 +116,7 @@ public class FilterBAM extends CommandLineProgram{
 		REF_SOFT_MATCHED_RETAINED, REF_SOFT_MATCHED_REJECTED, REF_HARD_MATCHED_RETAINED, REF_HARD_MATCHED_REJECTED
 	}
 	
-	public FilterBAM() {
+	public FilterBam() {
 	}
 	
 	@Override
@@ -420,6 +420,6 @@ public class FilterBAM extends CommandLineProgram{
 	
 	/** Stock main method. */
 	public static void main(final String[] args) {
-		System.exit(new FilterBAM().instanceMain(args));
+		System.exit(new FilterBam().instanceMain(args));
 	}
 }

--- a/src/java/org/broadinstitute/dropseqrna/utils/FilterBamByTag.java
+++ b/src/java/org/broadinstitute/dropseqrna/utils/FilterBamByTag.java
@@ -47,9 +47,9 @@ import picard.cmdline.CommandLineProgram;
 import picard.cmdline.StandardOptionDefinitions;
 
 @CommandLineProgramProperties(summary = "Filters a BAM file based on a TAG and a file containing a list of values.  This is pretty similar to grepping with a file, but is faster and makes a proper BAM.", oneLineSummary = "Filters a BAM file based on a TAG and a file containing a list of values.", programGroup = DropSeq.class)
-public class FilterBAMByTag extends CommandLineProgram {
+public class FilterBamByTag extends CommandLineProgram {
 
-	private final Log log = Log.getInstance(FilterBAMByTag.class);
+	private final Log log = Log.getInstance(FilterBamByTag.class);
 
 	@Argument(shortName = StandardOptionDefinitions.INPUT_SHORT_NAME, doc = "The input SAM or BAM file to analyze.")
 	public File INPUT;
@@ -220,6 +220,6 @@ public class FilterBAMByTag extends CommandLineProgram {
 
 	/** Stock main method. */
 	public static void main(final String[] args) {
-		System.exit(new FilterBAMByTag().instanceMain(args));
+		System.exit(new FilterBamByTag().instanceMain(args));
 	}
 }

--- a/src/java/org/broadinstitute/dropseqrna/utils/editdistance/CollapseBarcodesInPlace.java
+++ b/src/java/org/broadinstitute/dropseqrna/utils/editdistance/CollapseBarcodesInPlace.java
@@ -33,7 +33,7 @@ import org.broadinstitute.barclay.argparser.Argument;
 import org.broadinstitute.barclay.argparser.CommandLineProgramProperties;
 import org.broadinstitute.dropseqrna.barnyard.BarcodeListRetrieval;
 import org.broadinstitute.dropseqrna.cmdline.DropSeq;
-import org.broadinstitute.dropseqrna.metrics.BAMTagHistogram;
+import org.broadinstitute.dropseqrna.metrics.BamTagHistogram;
 import org.broadinstitute.dropseqrna.utils.ObjectCounter;
 import org.broadinstitute.dropseqrna.utils.readiterators.SamFileMergeUtil;
 import org.broadinstitute.dropseqrna.utils.readiterators.SamHeaderAndIterator;
@@ -127,7 +127,7 @@ public class CollapseBarcodesInPlace extends CommandLineProgram {
 
 		// gather up the barcodes that exist in the BAM
         final SamHeaderAndIterator inputs2 = openInputs();
-		ObjectCounter<String> barcodes = new BAMTagHistogram().getBamTagCounts(inputs2.iterator, this.PRIMARY_BARCODE,this.READ_QUALITY, this.FILTER_PCR_DUPLICATES);
+		ObjectCounter<String> barcodes = new BamTagHistogram().getBamTagCounts(inputs2.iterator, this.PRIMARY_BARCODE,this.READ_QUALITY, this.FILTER_PCR_DUPLICATES);
         CloserUtil.close(inputs2.iterator);
 
 		// filter barcodes by #reds in each barcode.

--- a/src/tests/java/org/broadinstitute/dropseqrna/annotation/ReduceGtfTest.java
+++ b/src/tests/java/org/broadinstitute/dropseqrna/annotation/ReduceGtfTest.java
@@ -36,7 +36,7 @@ import org.testng.annotations.Test;
 import htsjdk.samtools.util.CollectionUtil;
 
 
-public class ReduceGTFTest {
+public class ReduceGtfTest {
 
 	File GTF_FILE1 = new File("testdata/org/broadinstitute/transcriptome/annotation/human_ISG15.gtf.gz");
 	File GTF_FILE2 = new File("testdata/org/broadinstitute/transcriptome/annotation/human_ISG15_FAM41C.gtf.gz");
@@ -52,7 +52,7 @@ public class ReduceGTFTest {
 
 
     private Iterator<GTFRecord> parseGtf(final File file) {
-        ReduceGTF r = new ReduceGTF();
+        ReduceGtf r = new ReduceGtf();
         r.SEQUENCE_DICTIONARY = SD;
         r.GTF = file;
         return r.parseGTF();
@@ -63,11 +63,11 @@ public class ReduceGTFTest {
 
     @Test
     public void testDoWork () {
-    	ReduceGTF r = new ReduceGTF();
+    	ReduceGtf r = new ReduceGtf();
     	r.GTF=GTF_FILE5;
     	r.SEQUENCE_DICTIONARY=SD;
-    	File o = getTempReportFile("ReduceGTF", ".reduced.gtf.gz");
-    	// File o2 = getTempReportFile("ReduceGTF", ".reduced.gtf");
+    	File o = getTempReportFile("ReduceGtf", ".reduced.gtf.gz");
+    	// File o2 = getTempReportFile("ReduceGtf", ".reduced.gtf");
     	o.deleteOnExit();
     	// o2.deleteOnExit();
     	//r.OUTPUT=GTF_FILE5_REDUCED;

--- a/src/tests/java/org/broadinstitute/dropseqrna/barnyard/DigitalExpressionTest.java
+++ b/src/tests/java/org/broadinstitute/dropseqrna/barnyard/DigitalExpressionTest.java
@@ -65,7 +65,7 @@ public class DigitalExpressionTest {
 	 * HUMAN_15:101821715-101835487:SNRPA1
 	 * HUMAN_3:42642106-42690227:NKTR
 	 *
-	 * /fg/software/gap/gap_analysis/FilterBAMByTag I=100cells_star_bq10_noPseudoGenes.bam O=test.bam TAG=ZC TAG_VALUES_FILE=bc.txt ACCEPT_TAG=true
+	 * /fg/software/gap/gap_analysis/FilterBamByTag I=100cells_star_bq10_noPseudoGenes.bam O=test.bam TAG=ZC TAG_VALUES_FILE=bc.txt ACCEPT_TAG=true
 	 * samtools view -H test.bam > 5cell3gene.sam
 	 * samtools view test.bam |grep -f genes.txt >> 5cell3gene.sam
 	 * samtools view -Sb 5cell3gene.sam > 5cell3gene.bam

--- a/src/tests/java/org/broadinstitute/dropseqrna/barnyard/SingleCellRnaSeqMetricsCollectorTest.java
+++ b/src/tests/java/org/broadinstitute/dropseqrna/barnyard/SingleCellRnaSeqMetricsCollectorTest.java
@@ -41,12 +41,12 @@ public class SingleCellRnaSeqMetricsCollectorTest {
 
 	/**
 	 * Data for this test is generated from the following procedure (data is from the Barnyard_Runs2014/9-27-14_NextSeq/bams directory):
-	 * /broad/mccarroll/software/dropseq/prod/BAMTagHistogram I=/broad/mccarroll/evan/Barnyard_Runs2015/4-19-15_NextSeq/mm10/bams/P3Bipolars.bam O=P3Bipolars_reads_histogram.txt TAG=XC READ_QUALITY=10
+	 * /broad/mccarroll/software/dropseq/prod/BamTagHistogram I=/broad/mccarroll/evan/Barnyard_Runs2015/4-19-15_NextSeq/mm10/bams/P3Bipolars.bam O=P3Bipolars_reads_histogram.txt TAG=XC READ_QUALITY=10
 	 * head -n 10 P3Bipolars_reads_histogram.txt |cut -f 2 |tail -n 2 > 2mouse_cells.txt
-	 * /broad/mccarroll/software/dropseq/jn_branch/FilterBAMByTag I=/broad/mccarroll/evan/Barnyard_Runs2015/4-19-15_NextSeq/mm10/bams/P3Bipolars.bam O=2MouseCells.bam TAG=XC TAG_VALUES_FILE=2mouse_cells.txt
+	 * /broad/mccarroll/software/dropseq/jn_branch/FilterBamByTag I=/broad/mccarroll/evan/Barnyard_Runs2015/4-19-15_NextSeq/mm10/bams/P3Bipolars.bam O=2MouseCells.bam TAG=XC TAG_VALUES_FILE=2mouse_cells.txt
 	 * java -jar /seq/software/picard/current/bin/picard.jar DownsampleSam I=2MouseCells.bam O=2MouseCells.bam_downsampled.bam P=0.05
-	 * /broad/mccarroll/software/dropseq/jn_branch/FilterBAMByTag I=2MouseCells.bam_downsampled.bam O=2MouseCells.bam_downsampled_CGTCACTTGCAC.bam TAG=XC TAG_VALUE=CGTCACTTGCAC
-	 * /broad/mccarroll/software/dropseq/jn_branch/FilterBAMByTag I=2MouseCells.bam_downsampled.bam O=2MouseCells.bam_downsampled_TTCGCCCGGCTT.bam TAG=XC TAG_VALUE=TTCGCCCGGCTT
+	 * /broad/mccarroll/software/dropseq/jn_branch/FilterBamByTag I=2MouseCells.bam_downsampled.bam O=2MouseCells.bam_downsampled_CGTCACTTGCAC.bam TAG=XC TAG_VALUE=CGTCACTTGCAC
+	 * /broad/mccarroll/software/dropseq/jn_branch/FilterBamByTag I=2MouseCells.bam_downsampled.bam O=2MouseCells.bam_downsampled_TTCGCCCGGCTT.bam TAG=XC TAG_VALUE=TTCGCCCGGCTT
 	 * java -jar /seq/software/picard/current/bin/picard.jar CollectRnaSeqMetrics I=2MouseCells.bam_downsampled_TTCGCCCGGCTT.bam O=TTCGCCCGGCTT.rna_seq_metrics.txt REF_FLAT=/broad/mccarroll/software/metadata/individual_reference/mm10/mm10.refFlat RIBOSOMAL_INTERVALS=/broad/mccarroll/software/metadata/individual_reference/mm10/mm10.rRNA.intervals STRAND_SPECIFICITY=NONE
 	 * java -jar /seq/software/picard/current/bin/picard.jar CollectRnaSeqMetrics I=2MouseCells.bam_downsampled_CGTCACTTGCAC.bam O=CGTCACTTGCAC.rna_seq_metrics.txt REF_FLAT=/broad/mccarroll/software/metadata/individual_reference/mm10/mm10.refFlat RIBOSOMAL_INTERVALS=/broad/mccarroll/software/metadata/individual_reference/mm10/mm10.rRNA.intervals STRAND_SPECIFICITY=NONE
 	 * /broad/mccarroll/software/dropseq/prod/SingleCellRnaSeqMetricsCollector I=2MouseCells.bam_downsampled.bam O=2MouseCells.bam_downsampled.rna_seq_metrics.txt CELL_BARCODE_TAG=XC ANNOTATIONS_FILE=/broad/mccarroll/software/metadata/individual_reference/mm10/mm10.refFlat RIBOSOMAL_INTERVALS=/broad/mccarroll/software/metadata/individual_reference/mm10/mm10.rRNA.intervals NUM_CORE_BARCODES=2 READ_MQ=0

--- a/src/tests/java/org/broadinstitute/dropseqrna/metrics/BamTagHistogramTest.java
+++ b/src/tests/java/org/broadinstitute/dropseqrna/metrics/BamTagHistogramTest.java
@@ -8,7 +8,7 @@ import org.testng.annotations.Test;
 import junit.framework.Assert;
 import picard.util.TabbedInputParser;
 
-public class BAMTagHistogramTest {
+public class BamTagHistogramTest {
 
 	private static final File IN_FILE = new File("testdata/org/broadinstitute/transcriptome/barnyard/5cell3gene_retagged.bam");
 	private static final File EXPECTED_RESULT = new File ("testdata/org/broadinstitute/dropseq/metrics/5cell3gene.counts_per_XC.txt");
@@ -16,9 +16,9 @@ public class BAMTagHistogramTest {
 
 	@Test
 	public void doWorkStringTag() throws IOException {
-		File outFile = File.createTempFile("BAMTagHistogramTest.", ".counts_XC.txt");
+		File outFile = File.createTempFile("BamTagHistogramTest.", ".counts_XC.txt");
 		outFile.deleteOnExit();
-		BAMTagHistogram bth = new BAMTagHistogram();
+		BamTagHistogram bth = new BamTagHistogram();
 		bth.INPUT=IN_FILE;
 		bth.OUTPUT=outFile;
 		bth.READ_QUALITY=10;
@@ -33,9 +33,9 @@ public class BAMTagHistogramTest {
 	@Test
 	public void doWorkIntegerTag() throws IOException {
 		File outFile=null;
-		outFile = File.createTempFile("BAMTagHistogramTest.", ".counts_NM.txt");
+		outFile = File.createTempFile("BamTagHistogramTest.", ".counts_NM.txt");
 		outFile.deleteOnExit();
-		BAMTagHistogram bth = new BAMTagHistogram();
+		BamTagHistogram bth = new BamTagHistogram();
 		bth.INPUT=IN_FILE;
 		bth.OUTPUT=outFile;
 		bth.READ_QUALITY=10;

--- a/src/tests/java/org/broadinstitute/dropseqrna/metrics/BamTagOfTagCountsTest.java
+++ b/src/tests/java/org/broadinstitute/dropseqrna/metrics/BamTagOfTagCountsTest.java
@@ -7,7 +7,7 @@ import org.apache.commons.io.FileUtils;
 import org.junit.Assert;
 import org.testng.annotations.Test;
 
-public class BAMTagofTagCountsTest {
+public class BamTagOfTagCountsTest {
 
 	private static final File IN_FILE = new File("testdata/org/broadinstitute/transcriptome/barnyard/5cell3gene_retagged.bam");
 	private static final File EXPECTED_OUT1 = new File("testdata/org/broadinstitute/transcriptome/barnyard/tag_of_tag_XC_XM.txt");
@@ -17,12 +17,12 @@ public class BAMTagofTagCountsTest {
 	public void testDoWorkXCXM() {
 		File outFile=null;
 		try {
-			outFile = File.createTempFile("BAMTagofTagCounts.", ".out.txt");
+			outFile = File.createTempFile("BamTagOfTagCounts.", ".out.txt");
 		} catch (IOException e) {
 			e.printStackTrace();
 		}
 
-		BAMTagofTagCounts b = new BAMTagofTagCounts();
+		BamTagOfTagCounts b = new BamTagOfTagCounts();
 		b.INPUT=IN_FILE;
 		b.PRIMARY_TAG="XC";
 		b.READ_QUALITY=0;
@@ -43,12 +43,12 @@ public class BAMTagofTagCountsTest {
 	public void testDoWorkXCNM() {
 		File outFile=null;
 		try {
-			outFile = File.createTempFile("BAMTagofTagCounts.", ".out.txt");
+			outFile = File.createTempFile("BamTagOfTagCounts.", ".out.txt");
 		} catch (IOException e) {
 			e.printStackTrace();
 		}
 
-		BAMTagofTagCounts b = new BAMTagofTagCounts();
+		BamTagOfTagCounts b = new BamTagOfTagCounts();
 		b.INPUT=IN_FILE;
 		b.PRIMARY_TAG="XC";
 		b.READ_QUALITY=0;

--- a/src/tests/java/org/broadinstitute/dropseqrna/utils/FilterBamByTagTest.java
+++ b/src/tests/java/org/broadinstitute/dropseqrna/utils/FilterBamByTagTest.java
@@ -37,7 +37,7 @@ import htsjdk.samtools.SAMRecord;
 import htsjdk.samtools.SAMRecordSetBuilder;
 import junit.framework.Assert;
 
-public class FilterBAMByTagTest {
+public class FilterBamByTagTest {
 
 	private static File PAIRED_INPUT_FILE=new File ("testdata/org/broadinstitute/dropseq/utils/paired_reads_tagged.bam");
 	private static File UNPAIRED_INPUT_FILE=new File ("testdata/org/broadinstitute/dropseq/utils/unpaired_reads_tagged.bam");
@@ -49,7 +49,7 @@ public class FilterBAMByTagTest {
 
 	@Test (enabled=true)
 	public void testDoWorkPaired () {
-		FilterBAMByTag f = new FilterBAMByTag();
+		FilterBamByTag f = new FilterBamByTag();
 		f.INPUT=PAIRED_INPUT_FILE;
 		f.OUTPUT=getTempReportFile("paired_input", ".bam");
 		f.TAG="XC";
@@ -72,7 +72,7 @@ public class FilterBAMByTagTest {
 
 	@Test
 	public void testDoWorkUnPaired () {
-		FilterBAMByTag f = new FilterBAMByTag();
+		FilterBamByTag f = new FilterBamByTag();
 		f.INPUT=UNPAIRED_INPUT_FILE;
 		f.OUTPUT=getTempReportFile("unpaired_input", ".bam");
 		f.TAG="XC";
@@ -124,7 +124,7 @@ public class FilterBAMByTagTest {
 
 		SAMRecord readNoAttribute = new SAMRecord(null);
 
-		FilterBAMByTag t = new FilterBAMByTag();
+		FilterBamByTag t = new FilterBamByTag();
 		// read has attribute, accept any value, want to retain read.
 		boolean flag1 = t.filterRead(readHasAttribute, tag, null, true);
 		Assert.assertFalse(flag1);
@@ -180,7 +180,7 @@ public class FilterBAMByTagTest {
 
 	@Test(enabled = true)
 	public void filterByReadNumberTest() {
-		FilterBAMByTag t = new FilterBAMByTag();
+		FilterBamByTag t = new FilterBamByTag();
 
 		// record paired and read is 1st
 		List<SAMRecord> recs = getPairedRead ();
@@ -224,7 +224,7 @@ public class FilterBAMByTagTest {
 
 	@Test
 	public void testArgErrors () {
-		FilterBAMByTag f = new FilterBAMByTag();
+		FilterBamByTag f = new FilterBamByTag();
 		f.INPUT=PAIRED_INPUT_FILE;
 		f.OUTPUT=getTempReportFile("paired_input", ".bam");
 		f.PAIRED_MODE=true;

--- a/src/tests/java/org/broadinstitute/dropseqrna/utils/FilterBamTest.java
+++ b/src/tests/java/org/broadinstitute/dropseqrna/utils/FilterBamTest.java
@@ -42,11 +42,11 @@ import htsjdk.samtools.SAMSequenceDictionary;
 import htsjdk.samtools.SAMSequenceRecord;
 import picard.sam.ValidateSamFile;
 
-public class FilterBAMTest {
+public class FilterBamTest {
 
 	@Test(enabled=true, groups = { "dropseq","transcriptome" })
 	public void testCigarFilter() {
-		FilterBAM b = new FilterBAM();
+		FilterBam b = new FilterBam();
 		b.SUM_MATCHING_BASES=40;
 
 
@@ -87,7 +87,7 @@ public class FilterBAMTest {
 
 	@Test(enabled=true, groups = { "dropseq","transcriptome" })
 	public void testNonPrimary() {
-		FilterBAM b = new FilterBAM();
+		FilterBam b = new FilterBam();
 		b.RETAIN_ONLY_PRIMARY_READS=true;
 
 		SAMRecord r = new SAMRecord(null);
@@ -108,7 +108,7 @@ public class FilterBAMTest {
 
 	@Test(enabled=true, groups = { "dropseq", "transcriptome" })
 	public void testMapQuality () {
-		FilterBAM b = new FilterBAM();
+		FilterBam b = new FilterBam();
 		b.MINIMUM_MAPPING_QUALITY=10;
 		SAMRecord r = new SAMRecord(null);
 		r.setMappingQuality(12);
@@ -123,7 +123,7 @@ public class FilterBAMTest {
 
 	@Test(enabled=true, groups = { "dropseq", "transcriptome" })
 	public void testSoftMatch () {
-		FilterBAM b = new FilterBAM();
+		FilterBam b = new FilterBam();
 		List<String> retained = new ArrayList<>();
 		retained.add("HUMAN");
 		b.REF_SOFT_MATCHED_RETAINED=retained;
@@ -150,7 +150,7 @@ public class FilterBAMTest {
 
 	@Test(enabled=true, groups = { "dropseq", "transcriptome" })
 	public void testExactMatch () {
-		FilterBAM b = new FilterBAM();
+		FilterBam b = new FilterBam();
 		List<String> retained = new ArrayList<>();
 		retained.add("HUMAN_CHR1");
 		b.REF_HARD_MATCHED_RETAINED=retained;
@@ -170,7 +170,7 @@ public class FilterBAMTest {
 
 	@Test(enabled=true, groups = { "dropseq", "transcriptome" })
 	public void testRejectOnTags () {
-		FilterBAM b = new FilterBAM();
+		FilterBam b = new FilterBam();
 		b.TAG_REJECT_COMBINE_FLAG="UNION";
 		List<String> tags = new ArrayList<>();
 		tags.add("XE");
@@ -194,7 +194,7 @@ public class FilterBAMTest {
 
 	@Test(enabled=true, groups = { "dropseq", "transcriptome" })
 	public void testAcceptOnTags () {
-		FilterBAM b = new FilterBAM();
+		FilterBam b = new FilterBam();
 		List<String> tags = new ArrayList<>();
 		tags.add("XE");
 		tags.add("XZ");
@@ -242,8 +242,8 @@ public class FilterBAMTest {
 	}
 
 	private File createInputSam() throws IOException {
-		final File inputSamFile = File.createTempFile("FilterBAMTest.", ".sam");
-		final File referenceFasta = File.createTempFile("FilterBAMTest.", ".fasta");
+		final File inputSamFile = File.createTempFile("FilterBamTest.", ".sam");
+		final File referenceFasta = File.createTempFile("FilterBamTest.", ".fasta");
 		inputSamFile.deleteOnExit();
 		referenceFasta.deleteOnExit();
 
@@ -294,7 +294,7 @@ public class FilterBAMTest {
 	public void testEndToEnd(final String organism1, final String organism2, final boolean stripPrefix,
                              final boolean dropSequences, final boolean soft, final boolean retain) throws IOException {
 		final File inputSam = createInputSam();
-		final File outputSam = File.createTempFile("FilterBAMTest." +
+		final File outputSam = File.createTempFile("FilterBamTest." +
                 String.format("stripPrefix_%s;dropSequences_%s;soft_%s;retain_%s", stripPrefix, dropSequences, soft, retain) + ".",
                 ".sam");
 		outputSam.deleteOnExit();
@@ -317,7 +317,7 @@ public class FilterBAMTest {
 		else
 			ref_filter = "REF_HARD_MATCHED_REJECTED";
         args.add(ref_filter + "=" + organism1);
-        final int ret = new FilterBAM().instanceMain(args.toArray(new String[args.size()]));
+        final int ret = new FilterBam().instanceMain(args.toArray(new String[args.size()]));
         Assert.assertEquals(0, ret);
         Assert.assertTrue(validateSamFile(outputSam));
 	}


### PR DESCRIPTION
Eliminate obsoleted fully-qualified class name from ant macro.