### PR TITLE
Fail fast if no files found.

### DIFF
--- a/src/java/org/broadinstitute/dropseqrna/metrics/CountUnmatchedSampleIndices.java
+++ b/src/java/org/broadinstitute/dropseqrna/metrics/CountUnmatchedSampleIndices.java
@@ -78,6 +78,11 @@ public class CountUnmatchedSampleIndices
             }
         }
 
+        if (allBarcodeFiles.isEmpty()) {
+            throw new RuntimeException("No barcode files found");
+        }
+        NUM_THREADS = Math.min(NUM_THREADS, allBarcodeFiles.size());
+
         final Iterator<File> barcodeFiles;
 
         if (NUM_THREADS > 1) {
@@ -151,7 +156,7 @@ public class CountUnmatchedSampleIndices
         @Override
         public Boolean call() throws Exception {
             for (final File barcodeFile: new IterableAdapter<>(barcodeFiles)) {
-                LOG.debug("Processing", barcodeFile);
+                LOG.info("Processing", barcodeFile);
                 final TabbedInputParser parser = new TabbedInputParser(false, barcodeFile);
                 for (final String[] row : parser) {
                     ++totalReads;

--- a/src/tests/java/org/broadinstitute/dropseqrna/metrics/CountUnmatchedSampleIndicesTest.java
+++ b/src/tests/java/org/broadinstitute/dropseqrna/metrics/CountUnmatchedSampleIndicesTest.java
@@ -66,7 +66,7 @@ public class CountUnmatchedSampleIndicesTest {
     @DataProvider(name="testBasicDataProvider")
     public Object[][]testBasicDataProvider() {
         return new Object[][] {
-            {1}, {2}, {4}, {8}
+            {1}, {2}, {4}, {8}, {100}
         };
     }
 }


### PR DESCRIPTION
Don't allocate more threads than there are files.
Make a little more verbose.