### PR TITLE
Fixed RequiredTagStringValuePredicate

### DIFF
--- a/src/java/org/broadinstitute/dropseqrna/utils/readiterators/RequiredTagStringValuePredicate.java
+++ b/src/java/org/broadinstitute/dropseqrna/utils/readiterators/RequiredTagStringValuePredicate.java
@@ -27,8 +27,8 @@ public class RequiredTagStringValuePredicate implements Predicate<SAMRecord> {
     @Override
     public boolean test(SAMRecord rec) {
     	// if values are null or empty, don't filter.
-    	if (values==null) return false;
-		if (values.isEmpty()) return false;
+    	if (values==null) return true;
+		if (values.isEmpty()) return true;
 		
 		boolean contains=values.contains(rec.getStringAttribute(this.requiredTag));
 		// if exclude filter if contained.

--- a/src/tests/java/org/broadinstitute/dropseqrna/utils/TestUtils.java
+++ b/src/tests/java/org/broadinstitute/dropseqrna/utils/TestUtils.java
@@ -74,6 +74,9 @@ public class TestUtils {
 		}
 		CloserUtil.close(e);
 		CloserUtil.close(a);
+		// one of the files is incomplete.
+		if (e.hasNext() || a.hasNext()) 
+			return false;		
 		return true;
 	}
 

--- a/src/tests/java/org/broadinstitute/dropseqrna/utils/readiterators/CellBarcodeFilteringIteratorTest.java
+++ b/src/tests/java/org/broadinstitute/dropseqrna/utils/readiterators/CellBarcodeFilteringIteratorTest.java
@@ -35,7 +35,47 @@ public class CellBarcodeFilteringIteratorTest {
 		r1.setAttribute(cellBCTag, "FOO");
 		Assert.assertTrue(f.filterOut(r1));
 
+	}
+	
+	@Test
+	public void filterOut2() {
+		Iterator<SAMRecord> underlyingIterator = Collections.emptyIterator();
+		Collection<String> cellBarcodesToKeep = null;
+		String cellBCTag ="XC";
 
+		CellBarcodeFilteringIterator f = new CellBarcodeFilteringIterator(underlyingIterator, cellBCTag, cellBarcodesToKeep);
+		SAMRecordSetBuilder b = new SAMRecordSetBuilder();
+		// second argument is the contig index which is 0 based.  So contig index=0 -> chr1.  index=2 -> chr3, etc.
+		b.addFrag("1", 0, 1, false);
+		SAMRecord r1 = b.getRecords().iterator().next();
+
+		r1.setAttribute(cellBCTag, "CELL1");
+		Assert.assertFalse(f.filterOut(r1));
+
+		r1.setAttribute(cellBCTag, "CELL2");
+		Assert.assertFalse(f.filterOut(r1));
 
 	}
+	
+	@Test
+	public void filterOut3() {
+		Iterator<SAMRecord> underlyingIterator = Collections.emptyIterator();
+		Collection<String> cellBarcodesToKeep = Collections.EMPTY_LIST;
+		String cellBCTag ="XC";
+
+		CellBarcodeFilteringIterator f = new CellBarcodeFilteringIterator(underlyingIterator, cellBCTag, cellBarcodesToKeep);
+		SAMRecordSetBuilder b = new SAMRecordSetBuilder();
+		// second argument is the contig index which is 0 based.  So contig index=0 -> chr1.  index=2 -> chr3, etc.
+		b.addFrag("1", 0, 1, false);
+		SAMRecord r1 = b.getRecords().iterator().next();
+
+		r1.setAttribute(cellBCTag, "CELL1");
+		Assert.assertFalse(f.filterOut(r1));
+
+		r1.setAttribute(cellBCTag, "CELL2");
+		Assert.assertFalse(f.filterOut(r1));
+
+	}
+	
+	
 }


### PR DESCRIPTION
When set of required values was/null empty, operation was incorrect
Added unit tests to validate correct operation.