### PR TITLE
Removed INPUT from DGECommandLineBase

### DIFF
--- a/src/java/org/broadinstitute/dropseqrna/barnyard/DGECommandLineBase.java
+++ b/src/java/org/broadinstitute/dropseqrna/barnyard/DGECommandLineBase.java
@@ -32,9 +32,6 @@ import picard.cmdline.StandardOptionDefinitions;
 
 public abstract class DGECommandLineBase extends GeneFunctionCommandLineBase {
 
-	@Argument(shortName = StandardOptionDefinitions.INPUT_SHORT_NAME, doc = "The input SAM or BAM file to analyze.")
-	public List<File> INPUT;
-	
 	@Argument(doc="The cell barcode tag.  If there are no reads with this tag, the program will assume that all reads belong to the same cell and process in single sample mode.")
 	public String CELL_BARCODE_TAG="XC";
 	

--- a/src/java/org/broadinstitute/dropseqrna/barnyard/DigitalExpression.java
+++ b/src/java/org/broadinstitute/dropseqrna/barnyard/DigitalExpression.java
@@ -85,7 +85,7 @@ import picard.cmdline.StandardOptionDefinitions;
 public class DigitalExpression extends DGECommandLineBase {
 
     private static final Log log = Log.getInstance(DigitalExpression.class);
-
+    
     @Argument(shortName = StandardOptionDefinitions.INPUT_SHORT_NAME, doc = "The input SAM or BAM file to analyze.")
     public File INPUT;
         

--- a/src/java/org/broadinstitute/dropseqrna/barnyard/GatherMolecularBarcodeDistributionByGene.java
+++ b/src/java/org/broadinstitute/dropseqrna/barnyard/GatherMolecularBarcodeDistributionByGene.java
@@ -69,6 +69,9 @@ public class GatherMolecularBarcodeDistributionByGene extends DGECommandLineBase
 
 	private static final Log log = Log.getInstance(GatherMolecularBarcodeDistributionByGene.class);
 
+	@Argument(shortName = StandardOptionDefinitions.INPUT_SHORT_NAME, doc = "The input SAM or BAM file to analyze. This argument can accept wildcards, or a file with the suffix .bam_list that contains the locations of multiple BAM files", minElements = 1)
+	public List<File> INPUT;
+	
 	@Argument(shortName = StandardOptionDefinitions.OUTPUT_SHORT_NAME, doc="Output file of with 4 columns: CELL, GENE, MOLECULAR BC, #Observations. This supports zipped formats like gz and bz2.")
 	public File OUTPUT;
 
@@ -80,7 +83,6 @@ public class GatherMolecularBarcodeDistributionByGene extends DGECommandLineBase
 		BufferedWriter out = IOUtil.openFileForBufferedWriting(OUTPUT);
 
 		writePerTranscriptHeader(out);
-
 
 		Set<String> cellBarcodes=new HashSet<>(new BarcodeListRetrieval().getCellBarcodes(this.INPUT, this.CELL_BARCODE_TAG, this.MOLECULAR_BARCODE_TAG,
                 this.GENE_NAME_TAG, this.GENE_STRAND_TAG, this.GENE_FUNCTION_TAG, this.STRAND_STRATEGY, this.LOCUS_FUNCTION_LIST,


### PR DESCRIPTION
Removed INPUT from abstract class, so DGE can continue to have a single file input, and gatherMolBarcode can use multiple BAM inputs.