### PR TITLE
Jn matrix market large file update

### DIFF
--- a/src/java/org/broadinstitute/dropseqrna/barnyard/digitalexpression/tools/DGEMatrix.java
+++ b/src/java/org/broadinstitute/dropseqrna/barnyard/digitalexpression/tools/DGEMatrix.java
@@ -694,13 +694,14 @@ public class DGEMatrix {
         log.info("Found [" + rows + "] genes and [" + cols +"] cells with [" + elements +"] non-zero entries");
         
         // initialize the sparse matrix
+        log.info("Initializing CRSMatrix with [" + (int) elements +"] elements");
         CRSMatrix m = CRSMatrix.zero(rows, cols, (int) elements);
+                
         // Progress logged to track reading.
         ProgressLogger pl = new ProgressLogger(log);
         for(final MatrixMarketReader.Element element : matrixReader){
         	pl.record("0",0);
 			m.set(element.row,element.col,element.realValue());
-			
         }
         
         CloserUtil.close(matrixReader);

--- a/src/java/org/broadinstitute/dropseqrna/barnyard/digitalexpression/tools/DGEMatrix.java
+++ b/src/java/org/broadinstitute/dropseqrna/barnyard/digitalexpression/tools/DGEMatrix.java
@@ -691,13 +691,18 @@ public class DGEMatrix {
             throw new RuntimeException("Number of rows in matrix does not agree with length of gene list in " + matrixReader.getFilename());
         if (cols != cellBarcodes.size())
             throw new RuntimeException("Number of columns in matrix does not agree with length of cell barcode list in " + matrixReader.getFilename());
-        log.info("Found [" + rows + "] genes and [" + cols +"] cells");
-
+        log.info("Found [" + rows + "] genes and [" + cols +"] cells with [" + elements +"] non-zero entries");
+        
         // initialize the sparse matrix
         CRSMatrix m = CRSMatrix.zero(rows, cols, (int) elements);
-        for (final MatrixMarketReader.Element element: matrixReader)
-			m.set(element.row, element.col, element.realValue());
-
+        // Progress logged to track reading.
+        ProgressLogger pl = new ProgressLogger(log);
+        for(final MatrixMarketReader.Element element : matrixReader){
+        	pl.record("0",0);
+			m.set(element.row,element.col,element.realValue());
+			
+        }
+        
         CloserUtil.close(matrixReader);
 		return (new DGEMatrix(cellBarcodes, geneNames, m));
 

--- a/src/java/org/broadinstitute/dropseqrna/barnyard/digitalexpression/tools/DGEMatrix.java
+++ b/src/java/org/broadinstitute/dropseqrna/barnyard/digitalexpression/tools/DGEMatrix.java
@@ -684,6 +684,9 @@ public class DGEMatrix {
                 cellBarcodes.set(i, cellBarcodePrefix + cellBarcodes.get(i));
         int rows = matrixReader.getNumRows();
         int cols = matrixReader.getNumCols();
+        long elements = matrixReader.getNumElements();
+        if (elements > Integer.MAX_VALUE)
+        	throw new IllegalStateException ("This matrix market has > 2^32 non-zero values and can't be processed by the CRSMatrix API");
         if (rows != geneNames.size())
             throw new RuntimeException("Number of rows in matrix does not agree with length of gene list in " + matrixReader.getFilename());
         if (cols != cellBarcodes.size())
@@ -691,7 +694,7 @@ public class DGEMatrix {
         log.info("Found [" + rows + "] genes and [" + cols +"] cells");
 
         // initialize the sparse matrix
-        CRSMatrix m = CRSMatrix.zero(rows, cols);
+        CRSMatrix m = CRSMatrix.zero(rows, cols, (int) elements);
         for (final MatrixMarketReader.Element element: matrixReader)
 			m.set(element.row, element.col, element.realValue());
 

--- a/src/java/org/broadinstitute/dropseqrna/cluster/MergeDgeOutputWriter.java
+++ b/src/java/org/broadinstitute/dropseqrna/cluster/MergeDgeOutputWriter.java
@@ -48,7 +48,7 @@ class MergeDgeOutputWriter {
      * @param genes row names.
      * @param cellBarcodes column names.
      */
-    public MergeDgeOutputWriter(final File rawDgeFile, final File scaledDgeFile, final int numNonZeroElements,
+    public MergeDgeOutputWriter(final File rawDgeFile, final File scaledDgeFile, final long numNonZeroElements,
                                 final List<String> genes, final List<String> cellBarcodes) {
         if (rawDgeFile == null && scaledDgeFile == null) {
             throw new IllegalArgumentException("Doesn't make sense to construct with both files null");

--- a/src/java/org/broadinstitute/dropseqrna/cluster/MergeDgeSparse.java
+++ b/src/java/org/broadinstitute/dropseqrna/cluster/MergeDgeSparse.java
@@ -174,7 +174,7 @@ public class MergeDgeSparse
 
         final GeneFiltererSorter geneFiltererSorter = new GeneFiltererSorter(MIN_CELLS, dges);
 
-        int totalNumElements = 0;
+        long totalNumElements = 0;
         final List<String> cellBarcodes = new ArrayList<>();
         for (final SparseDge dge : dges) {
             totalNumElements += dge.getNumNonZeroEntries();
@@ -240,6 +240,12 @@ public class MergeDgeSparse
     @Override
     protected String[] customCommandLineValidation() {
         String[] superMessages = super.customCommandLineValidation();
+        if (this.CELL_SIZE_OUTPUT_FILE!=null) IOUtil.assertFileIsWritable(this.CELL_SIZE_OUTPUT_FILE);
+        if (this.RAW_DGE_OUTPUT_FILE!=null) IOUtil.assertFileIsWritable(this.RAW_DGE_OUTPUT_FILE);
+        if (this.SCALED_DGE_OUTPUT_FILE!=null) IOUtil.assertFileIsWritable(this.SCALED_DGE_OUTPUT_FILE);
+        if (this.DGE_HEADER_OUTPUT_FILE!=null) IOUtil.assertFileIsWritable(this.DGE_HEADER_OUTPUT_FILE);
+        if (this.DISCARDED_CELLS_FILE!=null) IOUtil.assertFileIsWritable(this.DISCARDED_CELLS_FILE);
+                
         if (RAW_DGE_OUTPUT_FILE == null && SCALED_DGE_OUTPUT_FILE == null)
             return CustomCommandLineValidationHelper.makeValue(superMessages,
                     Collections.singletonList("At least one of RAW_DGE_OUTPUT_FILE and SCALED_DGE_OUTPUT_FILE should be set"));

--- a/src/java/org/broadinstitute/dropseqrna/matrixmarket/MatrixMarketReader.java
+++ b/src/java/org/broadinstitute/dropseqrna/matrixmarket/MatrixMarketReader.java
@@ -112,7 +112,7 @@ public class MatrixMarketReader
     private final BufferedReader reader;
     private final int numRows;
     private final int numCols;
-    private final int numElements;
+    private final long numElements;
     private final List<String> rowNames = new ArrayList<>();
     private final List<String> colNames = new ArrayList<>();
     private final MatrixMarketConstants.ElementType elementType;
@@ -187,7 +187,7 @@ public class MatrixMarketReader
             }
             numRows = Integer.parseInt(fields[0]);
             numCols = Integer.parseInt(fields[1]);
-            numElements= Integer.parseInt(fields[2]);
+            numElements= Long.parseLong(fields[2]);          
 
             if (rowNames.size() != 0 && rowNames.size() != numRows) {
                 throw new RuntimeException(String.format("rowNames.size(%d) != numRows(%d)", rowNames.size(), numRows));
@@ -195,7 +195,7 @@ public class MatrixMarketReader
             if (colNames.size() != 0 && colNames.size() != numCols) {
                 throw new RuntimeException(String.format("colNames.size(%d) != numCols(%d)", colNames.size(), numCols));
             }
-            if ((long)numElements > numRows * (long)numCols) {
+            if (numElements > numRows * (long)numCols) {
                 throw new RuntimeException(String.format("numElements(%d) > numRows(%d) * numCols(%d)", numElements, numRows, numCols));
             }
 
@@ -224,7 +224,7 @@ public class MatrixMarketReader
         return numCols;
     }
 
-    public int getNumElements() {
+    public long getNumElements() {
         return numElements;
     }
 

--- a/src/java/org/broadinstitute/dropseqrna/matrixmarket/MatrixMarketWriter.java
+++ b/src/java/org/broadinstitute/dropseqrna/matrixmarket/MatrixMarketWriter.java
@@ -145,7 +145,7 @@ public class MatrixMarketWriter
      * @param col 0-based
      * @param val value to be written
      */
-    public void writeTriplet(final long row, final long col, final long val) {
+    public void writeTriplet(final long row, final long col, final int val) {
         try {
             assertGoodIndices(row, col);
             writer.write(String.format("%d\t%d\t%d\n", row+1, col+1, val));

--- a/src/java/org/broadinstitute/dropseqrna/matrixmarket/MatrixMarketWriter.java
+++ b/src/java/org/broadinstitute/dropseqrna/matrixmarket/MatrixMarketWriter.java
@@ -39,10 +39,10 @@ public class MatrixMarketWriter
     private final BufferedWriter writer;
     private final String filename;
     private final MatrixMarketConstants.ElementType elementType;
-    private final int numRows;
-    private final int numCols;
-    private final int numNonZeroElements;
-    private int numElementsWritten;
+    private final long numRows;
+    private final long numCols;
+    private final long numNonZeroElements;
+    private long numElementsWritten;
 
     /**
      *
@@ -57,7 +57,7 @@ public class MatrixMarketWriter
                               final MatrixMarketConstants.ElementType elementType,
                               final int numRows,
                               final int numCols,
-                              final int numNonZeroElements,
+                              final long numNonZeroElements,
                               final List<String> rowNames,
                               final List<String> colNames,
                               final String rowNamesLabel,
@@ -80,7 +80,7 @@ public class MatrixMarketWriter
                               final MatrixMarketConstants.ElementType elementType,
                               final int numRows,
                               final int numCols,
-                              final int numNonZeroElements,
+                              final long numNonZeroElements,
                               final List<String> rowNames,
                               final List<String> colNames,
                               String rowNamesLabel,
@@ -145,7 +145,7 @@ public class MatrixMarketWriter
      * @param col 0-based
      * @param val value to be written
      */
-    public void writeTriplet(final int row, final int col, final int val) {
+    public void writeTriplet(final long row, final long col, final long val) {
         try {
             assertGoodIndices(row, col);
             writer.write(String.format("%d\t%d\t%d\n", row+1, col+1, val));
@@ -159,7 +159,7 @@ public class MatrixMarketWriter
      * @param col 0-based
      * @param val value to be written, with 8 digits of precision.
      */
-    public void writeTriplet(final int row, final int col, final double val) {
+    public void writeTriplet(final long row, final long col, final double val) {
         try {
             if (elementType != MatrixMarketConstants.ElementType.real) {
                 throw new UnsupportedOperationException("Cannot write floating-point value to integer matrix");
@@ -171,7 +171,7 @@ public class MatrixMarketWriter
         }
     }
 
-    private void assertGoodIndices(final int row, final int col) {
+    private void assertGoodIndices(final long row, final long col) {
         if (row >= numRows) {
             throw new IllegalArgumentException(String.format("row(%d) >= numRows(%d)", row, numRows));
         }


### PR DESCRIPTION
DgeMatrix now uses long for number of non-zero entries when parsing matrix market data.