### PR TITLE
Jn census update

### DIFF
--- a/src/java/org/broadinstitute/dropseqrna/censusseq/CensusSeq.java
+++ b/src/java/org/broadinstitute/dropseqrna/censusseq/CensusSeq.java
@@ -333,7 +333,7 @@ public class CensusSeq extends CommandLineProgram {
 
 		String [] header={"NUM_POSSIBLE_SNPS="+numPossibleSNPs, "NUM_SNPS_USED="+numSNPsFound, "CONVERGED="+result.isConverged(), "BEST_LIKELIHOOD="+result.getBestLikelihood(), "SECOND_LIKELIHOOD="+result.getSecondBestLikelihood(),
 				"LIKELIHOOD_DELTA=" + result.getLikelihoodDelta(), "NORMALIZED_LIKELIHOOD="+result.getNormalizedLikelihood(), "SHANNON_WEAVER_DIVERSITY="+divFormat.format(diversity), "SHANNON_WEAVER_EQUITABILITY="+divFormat.format(equitability),
-				"KNOWN_DONOR_TAG="+ kdt};
+				"KNOWN_DONOR_TAG="+ kdt, "SCALE_ADJUSTMENT_DONOR_REP="+Boolean.toString(this.SCALE_ADJUSTMENT_DONOR_REP)};
 
 		String h = StringUtils.join(header, "\t");
 

--- a/src/java/org/broadinstitute/dropseqrna/censusseq/CensusSeq.java
+++ b/src/java/org/broadinstitute/dropseqrna/censusseq/CensusSeq.java
@@ -145,8 +145,11 @@ public class CensusSeq extends CommandLineProgram {
 	// public Boolean RANDOMIZED_START=false;
 
 	@Argument(doc="EXPERIMENTAL: If true, the adjustment factor for each SNP is scaled by the donor representation at the current iteration.  This"
-			+ "should allow the algorithm to deal with missing donors with low representation more gracefully.")
-	public Boolean SCALE_ADJUSTMENT_DONOR_REP=false;
+			+ "should allow the algorithm to deal with missing donors with low representation more gracefully.  This feature has been stress tested on"
+			+ "both a large number of in-silico mixing experiments from the manuscript as well as a number of problematic real world data sets, and performs "
+			+ "as well or better in all cases, at the cost of a slightly longer run time to reach convergence.  If set to false, defaults to the publication"
+			+ "algorithm settings.")
+	public Boolean SCALE_ADJUSTMENT_DONOR_REP=true;
 	
 	@Override
 	public int doWork() {

--- a/src/java/org/broadinstitute/dropseqrna/censusseq/CensusSeq.java
+++ b/src/java/org/broadinstitute/dropseqrna/censusseq/CensusSeq.java
@@ -146,7 +146,7 @@ public class CensusSeq extends CommandLineProgram {
 
 	@Argument(doc="EXPERIMENTAL: If true, the adjustment factor for each SNP is scaled by the donor representation at the current iteration.  This"
 			+ "should allow the algorithm to deal with missing donors with low representation more gracefully.")
-	public Boolean SCALE_ADJUSTMENT_DONOR_REP=true;
+	public Boolean SCALE_ADJUSTMENT_DONOR_REP=false;
 	
 	@Override
 	public int doWork() {

--- a/src/java/org/broadinstitute/dropseqrna/censusseq/CensusSeq.java
+++ b/src/java/org/broadinstitute/dropseqrna/censusseq/CensusSeq.java
@@ -144,6 +144,10 @@ public class CensusSeq extends CommandLineProgram {
 	// @Argument(doc="If convergence doesn't occur, use randomized donor frequency start.")
 	// public Boolean RANDOMIZED_START=false;
 
+	@Argument(doc="EXPERIMENTAL: If true, the adjustment factor for each SNP is scaled by the donor representation at the current iteration.  This"
+			+ "should allow the algorithm to deal with missing donors with low representation more gracefully.")
+	public Boolean SCALE_ADJUSTMENT_DONOR_REP=true;
+	
 	@Override
 	public int doWork() {
 		
@@ -258,13 +262,13 @@ public class CensusSeq extends CommandLineProgram {
 		// initialize random seed
 		final Random random = this.RANDOM_SEED == null ? new Random() : new Random(this.RANDOM_SEED);
 
-		OptimizeSampleRatiosCommonSNPs optim = new OptimizeSampleRatiosCommonSNPs(data, NUM_THREADS, random, false);
+		OptimizeSampleRatiosCommonSNPs optim = new OptimizeSampleRatiosCommonSNPs(data, SCALE_ADJUSTMENT_DONOR_REP, NUM_THREADS, random, false);
 		OptimizeSampleRatiosCommonSNPsResult result = optim.directIteration();
 		int restartCounter=0;
 		while (!result.isConverged() && restartCounter<this.MAX_RESTARTS) {
 			restartCounter++;
 			log.info("Likelihoods did not converge, restarting with randomized start positions, retry ["+ restartCounter+"].");
-			optim = new OptimizeSampleRatiosCommonSNPs(data, NUM_THREADS, random, true);
+			optim = new OptimizeSampleRatiosCommonSNPs(data, SCALE_ADJUSTMENT_DONOR_REP, NUM_THREADS, random, true);
 			OptimizeSampleRatiosCommonSNPsResult resultNew = optim.directIteration();
 			if (resultNew.getBestLikelihood()> result.getBestLikelihood()) {
 				log.info("Restart with random positions found better maximum likelihood [" + resultNew.getBestLikelihood() +"] old result [" + result.getBestLikelihood()+"]");

--- a/src/java/org/broadinstitute/dropseqrna/censusseq/CommonSNPsData.java
+++ b/src/java/org/broadinstitute/dropseqrna/censusseq/CommonSNPsData.java
@@ -187,6 +187,8 @@ public class CommonSNPsData {
 		}
 		if (Double.isNaN(result))
 			log.warn("SNP produced NaN allele frequency: ratios [" + ratios.toString() +" ] genotypes [" + this);
+		if (result <0 | result > 1)
+			log.warn("MAF [" + result +"] is out of bounds!");
 		return (result);
 	}
 

--- a/src/java/org/broadinstitute/dropseqrna/censusseq/OptimizeSampleRatiosCommonSNPs.java
+++ b/src/java/org/broadinstitute/dropseqrna/censusseq/OptimizeSampleRatiosCommonSNPs.java
@@ -30,6 +30,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 import org.apache.commons.math3.optim.univariate.UnivariatePointValuePair;
 
@@ -61,13 +63,11 @@ public class OptimizeSampleRatiosCommonSNPs {
 		this.random=random;
 	}
 
-	public OptimizeSampleRatiosCommonSNPsResult directIteration () {
-
+	private OptimizeSampleRatiosCommonSNPsResult directIteration (double[] startingMixture) {
 		boolean converged=false;
 		List<double [] > mixtureResults = new ArrayList<>();
 		List<Double> likelihoodResults = new ArrayList<>();
 
-		double[] startingMixture = getStartPoint(data.getSampleNames().size(), 1, this.randomizedStarts);
 		mixtureResults.add(startingMixture);
 		double startLikelihood=func.value(startingMixture);
 		likelihoodResults.add (startLikelihood);
@@ -140,9 +140,6 @@ public class OptimizeSampleRatiosCommonSNPs {
 		// now that you know which iteration did the best output the mixture results.
 		double [] maximizedMixture = mixtureResults.get(maxLikelihoodIndex);
 
-		// can this be reduced further by explicitly minimizing donors?
-
-
 		List<String> donors =  func.getDonorNames();
 
 		Map<String, Double> finalRatios = new HashMap<>();
@@ -153,15 +150,136 @@ public class OptimizeSampleRatiosCommonSNPs {
 		Collections.sort(likelihoodResults);
 		Collections.reverse(likelihoodResults);
 
-		// TODO what if there was a polishing stage where each donor was reduced to the minimum mixture value and the likelihood calculated?
-		// If there was any donor that was removed that made the data more likely, select the donor removal that improves likelihood score the most
-		// Then iterate until there are no more donors to minimize.
-		// TODO: when we have truly absent donors, are they the donors in the mixture that are fluctuating and thus not converging?
-		// could we check all donors that were not removed for convergence separately?  If all the non-zero donors converge we're good?  (Can test if they had already converged?)
-		// Would we need to run another round of optimization with those donors removed?  This might be more complicated if we have to remake the data object.
 		OptimizeSampleRatiosCommonSNPsResult result = new OptimizeSampleRatiosCommonSNPsResult(finalRatios, converged, likelihoodResults.get(0), likelihoodResults.get(1), this.data.getTotalSNPAlleleCounts(), this.randomizedStarts);
 
 		return result;
+
+	}
+	
+	public OptimizeSampleRatiosCommonSNPsResult directIteration () {
+		double[] startingMixture = getStartPoint(data.getSampleNames().size(), 1, this.randomizedStarts);
+		OptimizeSampleRatiosCommonSNPsResult phaseOneResult = directIteration(startingMixture);
+		return (phaseOneResult);
+		
+		// TODO: the likelihood calculation is undefined when the MAF is 0 or 1.
+		// Need to solve that before this has even a chance of working.
+		/*
+		double [] roundOneMixture = phaseOneResult.getMixtureArray(this.func.getDonorNames());
+		double [] zeroDonorOptimizedMixture =testForAbsentDonors2(roundOneMixture);
+
+		// if there were no changes made in the mixture, return the original optimization.
+		if (Arrays.equals(roundOneMixture, zeroDonorOptimizedMixture)) {
+			return (phaseOneResult);
+		}
+		
+		OptimizeSampleRatiosCommonSNPsResult finalResult = directIteration(zeroDonorOptimizedMixture);		
+		return (finalResult);
+		*/
+		
+	}
+	
+	/**
+	 * After optimizing mixture, try to iteratively remove donors from the pool.
+	 * Try to remove each donor and calculate the likelihood of the pool with the donor removed
+	 * Select the donor that when removed best improves the total likelihood.
+	 * If the likelihood does improve, set the donor proportion to 0, and test all non-zero donors
+	 * Continue until there is no donor removal that will improve the pool's total likelihood.
+	 *
+	 * @param startingMixture The proportion of donors in the pool after a first pass optimization
+	 * @return The proportion of donors after trying to remove donors from the pool 
+	 */
+	//TODO: fix likelihood at MAF=0 or MAF=1 to use this.  This is the "right" way to do this analysis.
+	private double [] testForAbsentDonors (double [] startingMixture ) {
+		
+		double mixLikelihood=func.value(startingMixture);
+		boolean searchActive=true;
+		
+		// make an explicit copy of the starting mixture.
+		double [] mixture = startingMixture.clone();
+				
+		// while active, try to remove another donor each pass.
+		while (searchActive) {
+			int [] indexesToTest = getNonZeroRepDonorIndex(mixture);
+			IntStream is = Arrays.stream(indexesToTest);
+			// IntStream is = IntStream.range(0, startingMixture.length);
+			//if (this.func.getNumThreads() > 1)
+			//	is = is.parallel();
+
+			List<Double> likelihoods=is.mapToObj(x-> getLikelihoodDonorRemoved(x,mixture)).collect(Collectors.toList());
+
+			int index = likelihoods.indexOf(Collections.max(likelihoods));
+			double bestLike = likelihoods.get(index);			
+			// if you can't find a likelihood 
+			if (bestLike<mixLikelihood) 
+				break;
+			// improvement?
+			if (bestLike>mixLikelihood) {
+				// set the donor that improved things to mixture = 0;
+				// since we're not testing all donors, we need to look up the correct original mixture index!
+				int mixtureIndex=indexesToTest[index];
+				mixture[mixtureIndex]=0;
+				log.info("Donor at position [" + mixtureIndex+"] mixture set to 0.  Previous pooled likelihood [" +mixLikelihood + "] new pooled likelihood [" + bestLike+"]");
+				// update the best likelihood
+				mixLikelihood=bestLike;
+				
+			}							
+		}
+		// the final optimized mixture.
+		return mixture;
+		
+		
+	}
+	
+	//TODO: this is a hackier way to do this, but the likelihood calculation is ill defined.
+	private double [] testForAbsentDonors2 (double [] startingMixture ) {
+		
+		double mixLikelihood=func.value(startingMixture);
+		log.info("Previous pooled likelihood [" +mixLikelihood + "]");
+		
+		// make an explicit copy of the starting mixture.
+		double [] mixture = startingMixture.clone();
+		
+		int [] indexesToTest = getNonZeroRepDonorIndex(mixture);
+		IntStream is = Arrays.stream(indexesToTest);
+		
+		
+		List<Double> likelihoods=is.mapToObj(x-> getLikelihoodDonorRemoved(x,mixture)).collect(Collectors.toList());
+		
+		// get all indexes where donor removal would improve the results.
+		for (int i=0; i<likelihoods.size(); i++) {
+			double thisLike=likelihoods.get(i);
+			
+			if (likelihoods.get(i)>mixLikelihood) {
+				log.info("Donor at position [" + i+"] mixture set to 0.  Pooled likelihood with this donor removed [" + thisLike+"]");
+				mixture[i]=0;
+			}
+		}
+		return mixture;
+		
+		
+	}
+	
+	
+	private int [] getNonZeroRepDonorIndex (double [] mixture) {
+		List<Integer> result = new ArrayList<>();
+		for (int i=0; i<mixture.length; i++) {
+			if (mixture[i]>0) result.add(i);
+		}
+		return result.stream().mapToInt(x->x).toArray();
+	}
+	
+	/**
+	 * For a given mixture vector, set the mixture at index to 0 and generate a likelihood.
+	 * @param index The index of the donor to test for removal
+	 * @param mixture The mixture vector
+	 * @return the likelihood of the mixture with the donor removed.
+	 */
+	private Double getLikelihoodDonorRemoved (int index, double [] mixture) {
+		// short circuit 
+		if (mixture[index]==0) return Double.MIN_VALUE;
+		double [] test = mixture.clone();
+		test[index]=0;
+		return func.value(test);						
 	}
 
 

--- a/src/java/org/broadinstitute/dropseqrna/censusseq/OptimizeSampleRatiosCommonSNPs.java
+++ b/src/java/org/broadinstitute/dropseqrna/censusseq/OptimizeSampleRatiosCommonSNPs.java
@@ -49,13 +49,13 @@ public class OptimizeSampleRatiosCommonSNPs {
 	// if likelihood changes less than this amount, data converged.
 	private final double minimumLikelihoodChange=0.1;
 
-	public OptimizeSampleRatiosCommonSNPs(final CommonSNPsData data, final int numThreads, final Random random) {
-		this(data, numThreads, random, false);
+	public OptimizeSampleRatiosCommonSNPs(final CommonSNPsData data, final boolean scaleToDonorRepresentation, final int numThreads, final Random random) {
+		this(data, scaleToDonorRepresentation, numThreads, random, false);
 	}
 
-	public OptimizeSampleRatiosCommonSNPs(final CommonSNPsData data, final int numThreads, final Random random, final boolean randomizedStarts) {
+	public OptimizeSampleRatiosCommonSNPs(final CommonSNPsData data, final boolean scaleToDonorRepresentation, final int numThreads, final Random random, final boolean randomizedStarts) {
 		func = new OptimizeSampleRatiosLikelihoodFunctionCommonSNPs(data, numThreads);
-		gradientFunc = new OptimizeSampleRatiosGradientFunction(data, numThreads);
+		gradientFunc = new OptimizeSampleRatiosGradientFunction(data, scaleToDonorRepresentation, numThreads);
 		this.data=data;
 		this.randomizedStarts=randomizedStarts;
 		this.random=random;

--- a/src/java/org/broadinstitute/dropseqrna/censusseq/OptimizeSampleRatiosCommonSNPs.java
+++ b/src/java/org/broadinstitute/dropseqrna/censusseq/OptimizeSampleRatiosCommonSNPs.java
@@ -59,6 +59,12 @@ public class OptimizeSampleRatiosCommonSNPs {
 	public OptimizeSampleRatiosCommonSNPs(final CommonSNPsData data, final boolean scaleToDonorRepresentation, final int numThreads, final Random random, final boolean randomizedStarts) {
 		func = new OptimizeSampleRatiosLikelihoodFunctionCommonSNPs(data, numThreads);
 		gradientFunc = new OptimizeSampleRatiosGradientFunction(data, scaleToDonorRepresentation, numThreads);
+
+		// this retains the old functionality / code path for backwards compatibility.
+		if (scaleToDonorRepresentation)
+			minimumMixture=1e-5;
+		else
+			minimumMixture=1e-12;			
 		this.data=data;
 		this.randomizedStarts=randomizedStarts;
 		this.random=random;

--- a/src/java/org/broadinstitute/dropseqrna/censusseq/OptimizeSampleRatiosCommonSNPsResult.java
+++ b/src/java/org/broadinstitute/dropseqrna/censusseq/OptimizeSampleRatiosCommonSNPsResult.java
@@ -23,6 +23,7 @@
  */
 package org.broadinstitute.dropseqrna.censusseq;
 
+import java.util.List;
 import java.util.Map;
 
 public class OptimizeSampleRatiosCommonSNPsResult {
@@ -45,6 +46,13 @@ public class OptimizeSampleRatiosCommonSNPsResult {
 
 	public Map<String, Double> getResult() {
 		return result;
+	}
+	
+	public double [] getMixtureArray(List<String> donors) {
+		double [] mixture=new double [donors.size()];
+		for (int i=0; i<donors.size();i++)
+			mixture[i]=result.get(donors.get(i));
+		return mixture;						
 	}
 
 	public boolean isConverged() {

--- a/src/java/org/broadinstitute/dropseqrna/censusseq/OptimizeSampleRatiosLikelihoodFunctionCommonSNPs.java
+++ b/src/java/org/broadinstitute/dropseqrna/censusseq/OptimizeSampleRatiosLikelihoodFunctionCommonSNPs.java
@@ -34,10 +34,7 @@ public class OptimizeSampleRatiosLikelihoodFunctionCommonSNPs implements Multiva
 
 	private final CommonSNPsData data;
 	private static final Log log = Log.getInstance(OptimizeSampleRatiosLikelihoodFunctionCommonSNPs.class);
-    private final int  numThreads;
-    // private double MIN_MAF;
-    // private double SOME_DUMB_CONSTANT=1e-12;
-    
+    private final int  numThreads;    
 	private Integer MAXIMUM_PENALITY=null;
 
     public OptimizeSampleRatiosLikelihoodFunctionCommonSNPs(final CommonSNPsData data, final int numThreads) {
@@ -63,14 +60,6 @@ public class OptimizeSampleRatiosLikelihoodFunctionCommonSNPs implements Multiva
 		IntToDoubleFunction calculateOne = (index) -> {
 			int [] refAltCounts = this.data.getRefAltCounts(index);
 			double minorAlleleFreq = this.data.getWeighedAlleleFrequenciesOneSNP(normalizedRatios, index);
-			/*
-			if (minorAlleleFreq < this.MIN_MAF) {
-				minorAlleleFreq=MIN_MAF;
-			}
-			if ((1-minorAlleleFreq) > (1-this.MIN_MAF)) {
-				minorAlleleFreq=(1-MIN_MAF);
-			}
-			*/
 			if (Double.isNaN(minorAlleleFreq))
 				log.warn("NaN MAF detected!");
 			double result = evaluateSNPProbability(minorAlleleFreq, refAltCounts);

--- a/src/java/org/broadinstitute/dropseqrna/censusseq/OptimizeSampleRatiosLikelihoodFunctionCommonSNPs.java
+++ b/src/java/org/broadinstitute/dropseqrna/censusseq/OptimizeSampleRatiosLikelihoodFunctionCommonSNPs.java
@@ -90,7 +90,7 @@ public class OptimizeSampleRatiosLikelihoodFunctionCommonSNPs implements Multiva
 	 * Where a is the count of the ref alleles, b is the count of the alt allelles, Fa is the frequency of the ref allele adjusted for the current
 	 * sample mixture ratios.
 	 * 
-	 * This is undefined when the MAF=0!
+	 * This is undefined when the MAF is not in the range of (0,1) [not inclusive!]
 	 * @param refAlleleFreq the reference allele freq
 	 * @param refAltCounts
 	 * @return

--- a/src/tests/java/org/broadinstitute/dropseqrna/censusseq/CensusSeqTest.java
+++ b/src/tests/java/org/broadinstitute/dropseqrna/censusseq/CensusSeqTest.java
@@ -42,6 +42,7 @@ public class CensusSeqTest {
 		f.SAMPLE_FILE=IN_SAMPLE_LIST;
 		f.REPORT_ALLELE_COUNTS=true;
 		f.SNP_COVERAGE_HISTOGRAM=File.createTempFile("testCensus.", ".snp_histogram.txt");
+		f.SCALE_ADJUSTMENT_DONOR_REP=false;
 		f.SNP_COVERAGE_HISTOGRAM.deleteOnExit();
 		// f.USE_JDK_DEFLATER=true;
 		String TMP_DIR=f.OUTPUT.getParent();
@@ -68,6 +69,7 @@ public class CensusSeqTest {
 		// f.USE_JDK_DEFLATER=true;
 		String TMP_DIR=f.OUTPUT.getParent();
 		f.TMP_DIR=Arrays.asList(new File (TMP_DIR));
+		f.SCALE_ADJUSTMENT_DONOR_REP=false;
 		int ret = f.doWork();
 		Assert.assertTrue(ret==0);
 	}
@@ -84,6 +86,7 @@ public class CensusSeqTest {
 		f.OUTPUT.deleteOnExit();
 		
 		f.SAMPLE_FILE=IN_WRONG_SAMPLE_LIST;
+		f.SCALE_ADJUSTMENT_DONOR_REP=false;
 		String TMP_DIR=f.OUTPUT.getParent();
 		//TODO: what's the proper way to get the TMP DIR?
 		f.TMP_DIR=Arrays.asList(new File (TMP_DIR));

--- a/src/tests/java/org/broadinstitute/dropseqrna/censusseq/CommonSNPsDataTest.java
+++ b/src/tests/java/org/broadinstitute/dropseqrna/censusseq/CommonSNPsDataTest.java
@@ -115,7 +115,7 @@ public class CommonSNPsDataTest {
 			Assert.assertEquals(resultEnd[i], expectedEnd[i], 0.001);
 		}
 	}
-
+	
 	@Test
 	public void testGetAllelesFreqsMissingData () {
 		double [] sampleMixtureStart = {0.25, 0.25, 0.25, 0.25};

--- a/src/tests/java/org/broadinstitute/dropseqrna/censusseq/OptimizeSampleRatiosCommonSNPsTest.java
+++ b/src/tests/java/org/broadinstitute/dropseqrna/censusseq/OptimizeSampleRatiosCommonSNPsTest.java
@@ -54,7 +54,7 @@ public class OptimizeSampleRatiosCommonSNPsTest {
 		CommonSNPsData d = CommonSNPsData.parseFromFiles(snpReadCountFile, genotypeFile);
 		// data was calculated with an iteration factor of 0.05, need to maintain that.
 		// changes to optimized iteration factor ruin this test.
-		OptimizeSampleRatiosCommonSNPs optim = new OptimizeSampleRatiosCommonSNPs(d, 1, null);
+		OptimizeSampleRatiosCommonSNPs optim = new OptimizeSampleRatiosCommonSNPs(d, false, 1, null);
 		Map<String, Double> ratioMap = optim.directIteration().getResult();
 
 		double [] answerDirectIteration=answerKey.get(2);
@@ -74,7 +74,7 @@ public class OptimizeSampleRatiosCommonSNPsTest {
 		File genotypeFile = new File("testdata/org/broadinstitute/dropseq/censusseq/sampleGenotypeStates.txt.gz");
 		CommonSNPsData d = CommonSNPsData.parseFromFiles(snpReadCountFile, genotypeFile);
 		Random random = new Random(1);
-		OptimizeSampleRatiosCommonSNPs optim = new OptimizeSampleRatiosCommonSNPs(d, 1, random);
+		OptimizeSampleRatiosCommonSNPs optim = new OptimizeSampleRatiosCommonSNPs(d, false, 1, random);
 		Map<String, Double> ratioMap = optim.directIteration().getResult();
 
 		// values of the donors after optimization.

--- a/src/tests/java/org/broadinstitute/dropseqrna/censusseq/OptimizeSampleRatiosGradientFunctionTest.java
+++ b/src/tests/java/org/broadinstitute/dropseqrna/censusseq/OptimizeSampleRatiosGradientFunctionTest.java
@@ -52,6 +52,8 @@ public class OptimizeSampleRatiosGradientFunctionTest {
 
 	*/
 
+	//TODO: should add some tests for donor scaling factor.  IE: OptimizeSampleRatiosGradientFunction(d, true)
+	//This is tested on multiple large data sets to determine efficacy.
 	@Test
 	public void testGradient () {
 
@@ -67,7 +69,7 @@ public class OptimizeSampleRatiosGradientFunctionTest {
 			d.addSNP(sampleNames, genos, ac[0], ac[1]);
 		}
 
-		OptimizeSampleRatiosGradientFunction f = new OptimizeSampleRatiosGradientFunction(d);
+		OptimizeSampleRatiosGradientFunction f = new OptimizeSampleRatiosGradientFunction(d, false);
 		double [] sampleMixtureStart = {0.25, 0.25, 0.25, 0.25};
 		double [] result = f.value(sampleMixtureStart);
 		double [] expected ={-1.790476, -2.647619,  3.085714,  1.352381};
@@ -98,7 +100,7 @@ public class OptimizeSampleRatiosGradientFunctionTest {
 			d.addSNP(sampleNames, genos, ac[0], ac[1]);
 		}
 
-		OptimizeSampleRatiosGradientFunction f = new OptimizeSampleRatiosGradientFunction(d);
+		OptimizeSampleRatiosGradientFunction f = new OptimizeSampleRatiosGradientFunction(d, false);
 		double [] sampleMixtureStart = {0.25, 0.25, 0.25, 0.25};
 		double [] result = f.value(sampleMixtureStart);
 		double [] expected ={-2.9333333, -0.9333333, 4.8000000, 1.0666667};


### PR DESCRIPTION
Update to CensusSeq:

Census now has an option (on by default) to scale the adjustment of donors at each iteration by the proportion of the donor from the last estimate.  This allows more smooth convergence of the mixture proportions and the ability to evaluate more difficult pools with many missing samples, at the cost of a slower convergence for more standard pools.  Likelihood of the data conditional on the donor mixture is equal or improved in all test cases.