### PR TITLE
Fixed a bug in the way that gene annotations are simplified 

### DIFF
--- a/src/java/org/broadinstitute/dropseqrna/annotation/FunctionalDataProcessor.java
+++ b/src/java/org/broadinstitute/dropseqrna/annotation/FunctionalDataProcessor.java
@@ -127,9 +127,9 @@ public class FunctionalDataProcessor {
     		for (FunctionalData fd: data) {
     			List<FunctionalData> l = map.get(fd.getGene());
     			if (l==null) {
-    				l = new ArrayList<FunctionalData>();
-    				l.add(fd);
+    				l = new ArrayList<FunctionalData>();    				
     			}
+    			l.add(fd);
     			map.put(fd.getGene(), l);
     		}
 
@@ -205,7 +205,7 @@ public class FunctionalDataProcessor {
     			if (fd==null) {
     				fd = new ArrayList<FunctionalData>();
     				originalDataByGene.put(sf.getGene(), fd);
-    			}
+    			}    			
     			fd.add(sf);
     		}
 			// test by gene

--- a/src/tests/java/org/broadinstitute/dropseqrna/utils/readiterators/FunctionalDataProcessorTest.java
+++ b/src/tests/java/org/broadinstitute/dropseqrna/utils/readiterators/FunctionalDataProcessorTest.java
@@ -230,7 +230,66 @@ public class FunctionalDataProcessorTest {
 
 	}
 
+	// Demonstrate interaction of a coding and intronic gene on the same read, with coding+intronic interpretation.
+	@Test
+	public void testExample1() {
+		LocusFunction [] acceptedFunctions = {LocusFunction.CODING, LocusFunction.UTR, LocusFunction.INTRONIC};
+		FunctionalDataProcessor fdp = new FunctionalDataProcessor(StrandStrategy.SENSE, acceptedFunctions);
+		String [] genes = {"A", "A", "B", "C"};
+		String [] strands = {"+", "+", "+", "-"};
+		LocusFunction [] locusFunctions = {LocusFunction.CODING, LocusFunction.INTRONIC, LocusFunction.INTRONIC, LocusFunction.INTRONIC};
 
+		// Read on the + strand.
+		List<FunctionalData> fdList = fdp.getFilteredFunctionalData(genes, strands, locusFunctions, false);
+		Assert.assertEquals(fdList.size(), 2);
 
+		// once you filter to the preferred annotations, only the coding gene is retained.
+		
+		fdList = fdp.filterToPreferredAnnotations(fdList);
+		Assert.assertEquals(fdList.size(), 1);
+
+	}
+
+	// Demonstrate interaction of a coding and intronic gene on the same read, with intronic interpretation.
+	@Test
+	public void testExample2() {
+		
+		LocusFunction [] acceptedFunctions = {LocusFunction.INTRONIC};
+		FunctionalDataProcessor fdp = new FunctionalDataProcessor(StrandStrategy.SENSE, acceptedFunctions);
+		String [] genes = {"A", "A", "B", "C"};
+		String [] strands = {"+", "+", "+", "-"};
+		LocusFunction [] locusFunctions = {LocusFunction.CODING, LocusFunction.INTRONIC, LocusFunction.INTRONIC, LocusFunction.INTRONIC};
+
+		// Read on the + strand.
+		// Because the read overlaps Gene A on both the intronic and exonic portions, the gene annotation is discarded.
+		List<FunctionalData> fdList = fdp.getFilteredFunctionalData(genes, strands, locusFunctions, false);
+		Assert.assertEquals(fdList.size(), 1);
+
+		// once you filter to the preferred annotations, only the coding gene is retained.		
+		fdList = fdp.filterToPreferredAnnotations(fdList);
+		Assert.assertEquals(fdList.size(), 1);
+
+	}
+
+	// Demonstrate interaction of a coding and intronic gene on the same read, with coding interpretation.
+	@Test
+	public void testExample3() {
+		
+		LocusFunction [] acceptedFunctions = {LocusFunction.CODING, LocusFunction.UTR};
+		FunctionalDataProcessor fdp = new FunctionalDataProcessor(StrandStrategy.SENSE, acceptedFunctions);
+		String [] genes = {"A", "A", "B", "C"};
+		String [] strands = {"+", "+", "+", "-"};
+		LocusFunction [] locusFunctions = {LocusFunction.CODING, LocusFunction.INTRONIC, LocusFunction.INTRONIC, LocusFunction.INTRONIC};
+
+		// Read on the + strand.
+		// Because the read overlaps Gene A on both the intronic and exonic portions, the gene annotation is discarded.
+		List<FunctionalData> fdList = fdp.getFilteredFunctionalData(genes, strands, locusFunctions, false);
+		Assert.assertEquals(fdList.size(), 0);
+
+		// once you filter to the preferred annotations, only the coding gene is retained.		
+		fdList = fdp.filterToPreferredAnnotations(fdList);
+		Assert.assertEquals(fdList.size(), 0);
+
+	}
 
 }


### PR DESCRIPTION
This changes reads that had multiple annotations for the same gene: IE reads that overlap an intron/exon boundry.  This should not change the coding+intronic values we've been calculating for the last few years.

In integration tests this does not change any expression outputs.  

Added a few more unit tests to demonstrate parsing a difficult read annotation scenario multiple ways.