### PR TITLE
Filter out sites with symbolic alleles when filtering to diploid sites

### DIFF
--- a/src/java/org/broadinstitute/dropseqrna/vcftools/filters/SimpleDiploidVariantContextFilter.java
+++ b/src/java/org/broadinstitute/dropseqrna/vcftools/filters/SimpleDiploidVariantContextFilter.java
@@ -103,6 +103,11 @@ public class SimpleDiploidVariantContextFilter extends FilteredIterator <Variant
 
 	@Override
 	public boolean filterOut(final VariantContext site) {
+		// Remove variants with symbolic alleles.
+		// These would not pass the isCanonicalAllele test later.
+		if (site.hasSymbolicAlleles()) {
+			return true;
+		}
 		// if requested, filter out any "filtered" site.
 		if (filterFilterFlagedVariants && site.isFiltered()) {
 			if (verbose) log.info("Rejecting variant site filtered "+site.toStringWithoutGenotypes());


### PR DESCRIPTION
See VCF spec for more details on symbolic alleles: https://samtools.github.io/hts-specs/VCFv4.3.pdf

These are complicated regions with (possibly) nested variants.  We don't need these for donor assignment or any method where we're directly observing simple alleles in sequence data.