### PR TITLE
Drop bashisms

### DIFF
--- a/src/scripts/create_Drop-seq_reference_metadata.sh
+++ b/src/scripts/create_Drop-seq_reference_metadata.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 # MIT License
 #
 # Copyright 2018 Broad Institute
@@ -21,10 +21,10 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-source "$(dirname "$0")"/defs.sh
+. "$(dirname "$0")"/defs.sh
 
 progname=$(basename "$0")
-function usage () {
+usage () {
     cat >&2 <<EOF
 USAGE: $progname [options]
 Create Drop-seq reference metadata bundle
@@ -57,8 +57,6 @@ star_executable=$(which STAR 2> /dev/null)
 samtools_executable=$(which samtools 2> /dev/null)
 bgzip_executable=$(which bgzip 2> /dev/null)
 set -e
-# Fail if any of the commands in a pipeline fails
-set -o pipefail
 
 
 


### PR DESCRIPTION
PR #401 addressed issues reported by shellcheck respecting the `#!/usr/bin/env bash` shebang.
This PR includes those changes but additionally removes all bash-isms from those scripts such that shellcheck passes with a plain `#!/bin/sh` shebang.
This increases portability by enabling to run those scripts on bash-less systems.

Previously used bash-features that had to be worked around are as follows:
1. `set -o pipefail`: Dropped, since neither script used a single pipe.
2. arrays (`files_to_delete`): Replaced by ~traps on exit without error.~ exploiting `$@` via `set --`.

---
~Notes:~

1. ~This has not been tested yet. I will report back once I have confirmed it does not break any functionality.  
Until the I'll leave this marked as a draft.~
2. ~This includes commit 4963503ae1219e526a8655c3dc1eaecddb1e3510 and thus all changes suggested in #401.  
Therefore, merging this PR first automatically closes #401.
See commit c0b1c077397e4a7fe7f560af3796bc4e7fca5495 for the additional changes suggested here or merge #401 first before reviewing this PR.~