### PR TITLE
Fix regression introduced by f235793

### DIFF
--- a/src/scripts/Drop-seq_alignment.sh
+++ b/src/scripts/Drop-seq_alignment.sh
@@ -63,8 +63,7 @@ set -e
 # for the corresponding discussion.
 unset \
   genomedir \
-  reference \
-  verbose
+  reference
 
 while getopts ':g:r:o:s:n:bekvh' options; do
   case $options in


### PR DESCRIPTION
PR #412 mistakenly unset the `verbose` parameter after its (zero) initialization in `defs.sh` leading to downstream errors.
This PR fixes this. The comment already claimed to consider sourced files but now this is actually true.

---
@alecw: Apologies for letting this slip though.