### PR TITLE
script bug fixes

### DIFF
--- a/src/scripts/create_Drop-seq_reference_metadata.sh
+++ b/src/scripts/create_Drop-seq_reference_metadata.sh
@@ -119,7 +119,7 @@ if [ -e "$sequence_dictionary" ]
 then $ECHO rm "$sequence_dictionary"
 fi
 invoke_picard CreateSequenceDictionary REFERENCE="$output_fasta" OUTPUT="$sequence_dictionary" SPECIES="$species"
-invoke_dropseq FilterGtf GTF="$gtf" SEQUENCE_DICTIONARY="$sequence_dictionary" OUTPUT="$output_gtf $filtered_gene_biotypes"
+invoke_dropseq FilterGtf GTF="$gtf" SEQUENCE_DICTIONARY="$sequence_dictionary" OUTPUT="$output_gtf" $filtered_gene_biotypes
 invoke_dropseq ConvertToRefFlat ANNOTATIONS_FILE="$output_gtf" SEQUENCE_DICTIONARY="$sequence_dictionary" OUTPUT="$outdir/$reference_name".refFlat
 invoke_dropseq ReduceGtf GTF="$output_gtf" SEQUENCE_DICTIONARY="$sequence_dictionary" OUTPUT="$reduced_gtf"
 invoke_dropseq CreateIntervalsFiles SEQUENCE_DICTIONARY="$sequence_dictionary" REDUCED_GTF="$reduced_gtf" PREFIX="$reference_name" \

--- a/src/scripts/defs.sh
+++ b/src/scripts/defs.sh
@@ -50,22 +50,6 @@ check_invoke() {
     fi
 }
 
-# Note: `"$thisdir"` might be a symbolic link to a directory. Appending a final
-# `/` ensures the link to be resolved in such a case and is a no-op otherwise.
-# Without this (or instructng `find` to follow symbolic links by passing the
-# `-L` flag), `find` would fail to detect the Picard `*.jar` file if this
-# script is called via a directory symlink.
-picard_jar=$(find "$thisdir"/ -name picard\*.jar)
-
-num_picard_jars=$(wc -w << EOF
-$picard_jar
-EOF
-)
-
-if [ "$num_picard_jars" -ne 1 ]
-then error_exit 'Could not find one and only one picard.jar in deployment.'
-fi
-
 invoke_picard() {
     check_invoke java -classpath "$all_classpath" -Xmx4g -Djava.io.tmpdir="$TMPDIR" picard.cmdline.PicardCommandLine "$@"
 }


### PR DESCRIPTION
- check for one and only one picard.jar is obsolete.
- if no -f arguments to create_Drop-seq_reference_metadata.sh, the filtered GTF had a trailing space