### PR TITLE
Fix for donor assignment negative infinity likelihoods.

### DIFF
--- a/src/java/org/broadinstitute/dropseqrna/barnyard/digitalallelecounts/LikelihoodUtils.java
+++ b/src/java/org/broadinstitute/dropseqrna/barnyard/digitalallelecounts/LikelihoodUtils.java
@@ -518,7 +518,7 @@ public class LikelihoodUtils {
 		// If this donor has the reference allele, use the referencee allele penalty.
 		double errrorProb = penaltyScores[0];
 		// otherwise use the alternate allele penalty
-		if (base!=referenceAllele) errrorProb = penaltyScores[1];		
+		if (base!=referenceAllele) errrorProb = penaltyScores[1];
 		double result = getLikelihoodHomozygote(alleleOne, alleleTwo, base, errrorProb, genotypeProbability);
 		return (result);
 	}

--- a/src/java/org/broadinstitute/dropseqrna/barnyard/digitalallelecounts/SummarizeUMIBaseQualities.java
+++ b/src/java/org/broadinstitute/dropseqrna/barnyard/digitalallelecounts/SummarizeUMIBaseQualities.java
@@ -105,6 +105,8 @@ public class SummarizeUMIBaseQualities {
 	 * Mean of : 0.999,0.999,0.1=0.6993333
 	 * Thus an error rate of 1-0.6993333=0.3006667, which is a phread base score of ~ 5.
 	 * We want to penalize bases with disagreements.
+	 * Note: Phred scores of 0 are not allowed (can't have an error rate of 1), so if the mean is 0, it's set to 1.
+	 * There's an issue here where the error rate will never be 1, but is quantized to 1 by the conversion to phred score.
 	 * @return
 	 */
 	public int getSummarizedPhreadScoreByMeanWithErrors () {
@@ -123,8 +125,11 @@ public class SummarizeUMIBaseQualities {
 				mean.increment(1-prob);
 		}
 		double meanErrorProbability = mean.getResult();
-		int phread = LikelihoodUtils.getInstance().errorProbabilityToPhredScore(meanErrorProbability);
-		return phread;
+		int phred = LikelihoodUtils.getInstance().errorProbabilityToPhredScore(meanErrorProbability);
+		// can't have a phread score of 0 for likeliylhood calculations.
+		if (phred==0)
+			phred=1;
+		return phred;
 	}
 
 	/**


### PR DESCRIPTION
Fix for edge case bug where multiple reads are summarized as a single UMI with a single phred score.  Due to the underlying error rating being quantized by the pred score, a very high error rate of 0.9 or higher is quantized to a phred score of 0.  This is equivalent to an error rate of 1 when the phred score is unpacked to a probability, which causes errors with the downstream likelihoods.

To fix this, during summarization, if the phred score is less than 1 it is set to 1.  This avoids issues in the likelihood calculations where having probabilities of 0 causes issues when logged (plus probabilities should always include some uncertainty, which is lost if a phred score is 0.)