### PR TITLE
Convert record counts to long

### DIFF
--- a/src/java/org/broadinstitute/dropseqrna/utils/FilteredIterator.java
+++ b/src/java/org/broadinstitute/dropseqrna/utils/FilteredIterator.java
@@ -38,8 +38,8 @@ public abstract class FilteredIterator<T>
     final PeekableIterator<T> it;
     boolean firstTime = true;
     private final ObjectSink<T> sink;
-    private int recordsPass=0;
-	private int recordsFail=0;
+    private long recordsPass=0;
+	private long recordsFail=0;
 	
         
     /**
@@ -132,12 +132,12 @@ public abstract class FilteredIterator<T>
     }
     
     @Override
-	public int getRecordsPassed() {
+	public long getRecordsPassed() {
 		return this.recordsPass;		
 	}
 
 	@Override
-	public int getRecordsFailed() {
+	public long getRecordsFailed() {
 		return this.recordsFail;
 	}
 }

--- a/src/java/org/broadinstitute/dropseqrna/utils/PassFailTrackingIteratorI.java
+++ b/src/java/org/broadinstitute/dropseqrna/utils/PassFailTrackingIteratorI.java
@@ -7,7 +7,7 @@ package org.broadinstitute.dropseqrna.utils;
  */
 public interface PassFailTrackingIteratorI {
 
-	public int getRecordsPassed();
-	public int getRecordsFailed();
+	public long getRecordsPassed();
+	public long getRecordsFailed();
 	
 }


### PR DESCRIPTION
In large datsets, 32 bit integers can be insufficient to counts the number of reads.
This PR replaces it by longs.

Reported by @jamesnemesh (https://github.com/broadinstitute/Drop-seq/issues/505).

Note:
A quick `git grep int\ record` did not reveal any additional hits. However, `git grep int\ read` reveals [a lot of places that might require conversion to long as well](https://github.com/search?q=repo%3Abroadinstitute%2FDrop-seq+%22int+read%22&type=code).

Therefore, I am creating this as a draft PR only for now to get a discussion started.

I think the quick search above contains quite some false positives, such as `readOneLength`, `readTwoLength`, `readMQ`, `readEditDistance`, `readQuality`, etc. that if at all should probably be changed into `short`s rather than `long`s.
However, things like `readsTrimmed`, `readsCompletelyTrimmed`, `numReadsTotal`, `readsRef`, `readsAlt`, `readCount` etc. look like they could grow quite large as well.

Personally, it even bothers me that Java doesn't allow us to declare all these as unsigned and we are effectively wasting half of the available integer range for negative counts and lengths but that's the way it is I guess. 😉