### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/DropSeq.eqtl.r.yml
+++ b/.github/workflows/DropSeq.eqtl.r.yml
@@ -8,13 +8,15 @@
 
 name: DropSeq.eqtl R package
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ "master" ]
   pull_request:
     branches: [ "master" ]
     paths: 'src/R/packages/DropSeq.eqtl/**'
-
 
 # See https://dirk.eddelbuettel.com/blog/code/r4/ for using r2u to speed up dependency loading
 jobs:

--- a/.github/workflows/python-dropseq_aggregation-conda.yml
+++ b/.github/workflows/python-dropseq_aggregation-conda.yml
@@ -1,5 +1,8 @@
 name: Python Package dropseq_aggregation using Conda
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ "master" ]
@@ -8,7 +11,6 @@ on:
     paths:
       - '.github/workflows/python-dropseq_aggregation-conda.yml'
       - 'src/python/dropseq_aggregation/**'
-
 
 jobs:
   build-linux:

--- a/.github/workflows/python-dropseq_hdf5-conda.yml
+++ b/.github/workflows/python-dropseq_hdf5-conda.yml
@@ -9,6 +9,8 @@ on:
       - '.github/workflows/python-dropseq_hdf5-conda.yml'
       - 'src/python/dropseq_hdf5/**'
 
+permissions:
+  contents: read
 
 jobs:
   build-linux:

--- a/.github/workflows/python-dropseq_terra_utils-conda.yml
+++ b/.github/workflows/python-dropseq_terra_utils-conda.yml
@@ -9,6 +9,8 @@ on:
       - '.github/workflows/python-dropseq_terra_utils-conda.yml'
       - 'src/python/dropseq_terra_utils/**'
 
+permissions:
+  contents: read
 
 jobs:
   build-linux:


### PR DESCRIPTION
Potential fix for [https://github.com/broadinstitute/Drop-seq/security/code-scanning/7](https://github.com/broadinstitute/Drop-seq/security/code-scanning/7)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will define the minimal permissions required for the workflow to function. Based on the provided workflow, it appears that the workflow primarily interacts with the repository contents and possibly pull requests. Therefore, we will set `contents: read` and add any additional permissions only if necessary.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
